### PR TITLE
fix(ui): disabled button tooltip at Chrome

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -198,7 +198,7 @@ export const Button = forwardRef<HTMLElement, ButtonProps>(
         visible={disabled && disabledTooltipVisible}
         placement={disabledTooltipPlacement}
       >
-        {(tooltipRef) => (
+        {(tooltipRef, onMouseEnter, onMouseLeave) => (
           <Component
             data-test="button"
             className={cn(
@@ -222,7 +222,9 @@ export const Button = forwardRef<HTMLElement, ButtonProps>(
             {...rest}
           >
             <span data-test="button-outline" className={cn(styles.outline, { [styles.inset]: outline === 'inset' }, outlineClassName)} />
-            <span className={cn(styles.body, bodyClassName)}>
+            <span className={cn(styles.body, bodyClassName)}
+                  onMouseEnter={onMouseEnter}
+                  onMouseLeave={onMouseLeave}>
               {loading && !loadingAnimationOnRight && <Loader className={styles.iconLeft} size="small" />}
               {iconLeft && iconLeftAriaLabel && !loading && (
                 <Icon

--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -11,7 +11,7 @@ import React, {
   useContext,
   useMemo,
   useRef,
-  useEffect,
+  useEffect, MouseEventHandler,
 } from 'react'
 import ReactDOM from 'react-dom'
 import { Placement } from '@popperjs/core'
@@ -58,7 +58,11 @@ export type TooltipProps = {
   padding?: number
   placement?: Placement
   visible?: boolean
-  children: (ref: React.Dispatch<React.SetStateAction<HTMLElement | null>>) => ReactNode
+  children: (
+    ref: React.Dispatch<React.SetStateAction<HTMLElement | null>>,
+    onMouseEnter?: MouseEventHandler<Element>,
+    onMouseLeave?: MouseEventHandler<Element>,
+  ) => ReactNode;
   popperRef?: MutableRefObject<PopperRef | undefined>
   updateToken?: ReactText | boolean
   tooltipContainer?: TooltipContainer
@@ -145,12 +149,13 @@ export const Tooltip: FC<TooltipProps> = ({
   const onMouseLeave = useCallback(
     (event?: Event) => {
       const e = event as MouseEvent
+      const { relatedTarget } = e ?? {};
 
       timeoutRef.current = setTimeout(() => {
-        if (e?.relatedTarget) {
+        if (relatedTarget) {
           if (
-            !containsElement(context?.referenceElement, e.relatedTarget as Node) &&
-            !containsElement(context?.popperElement, e.relatedTarget as Node)
+            !containsElement(context?.referenceElement, relatedTarget as Node) &&
+            !containsElement(context?.popperElement, relatedTarget as Node)
           ) {
             context?.hide()
           }
@@ -197,7 +202,9 @@ export const Tooltip: FC<TooltipProps> = ({
 
   return (
     <TooltipContext.Provider value={contextValue}>
-      {children(setReferenceElement)}
+      {children(setReferenceElement, onMouseEnter, (e: unknown) => {
+        onMouseLeave(e as Event);
+      })}
 
       {content !== undefined && (
         <>


### PR DESCRIPTION
### Bug
a disabled button's Tooltip does not work at Chrome Browser. 
https://5f80b6aa3ceb290022dfea61-iidxkhpxfe.chromatic.com/?path=/docs/components-button--disabled

### Problem
when the Button is disabled, that Chrome does not fire the mouse's events on it.

### Solution
add 2 needed events to an inner span element of the Button