### PR TITLE
fix(ui): tooltip messages in NumberField

### DIFF
--- a/packages/ui/src/NumberField.tsx
+++ b/packages/ui/src/NumberField.tsx
@@ -50,7 +50,7 @@ export const NumberField: FC<NumberFieldProps> = ({
   max,
   value,
   numberType = 'int',
-  iconPosition= 'together',
+  iconPosition = 'together',
   showIconButtons = true,
   inputClassName,
   inputContainerClassName,
@@ -108,7 +108,7 @@ export const NumberField: FC<NumberFieldProps> = ({
     } else if (min !== undefined && value <= min) {
       decrementDisabledProps = {
         disabled: true,
-        disabledTooltip: `Value must be greater than ${min}`,
+        disabledTooltip: `Value can't be less than ${min}`,
       }
     } else if (disabled) {
       // The entire input is disabled. No need for a tooltip.
@@ -128,7 +128,7 @@ export const NumberField: FC<NumberFieldProps> = ({
     } else if (max !== undefined && value !== undefined && value >= max) {
       incrementDisabledProps = {
         disabled: true,
-        disabledTooltip: `Value must be less than ${max}`,
+        disabledTooltip: `Value can't be greater than ${max}`,
       }
     } else if (disabled) {
       // The entire input is disabled. No need for a tooltip.
@@ -145,12 +145,11 @@ export const NumberField: FC<NumberFieldProps> = ({
           size={size === 'small' ? 'small' : 'smallMedium'}
           icon={MinusCircle}
           ariaLabel={decrementIconAriaLabel}
-          className={cn(styles.decrement,
-            {
-              [styles.decrementSmall]: size === 'small',
-              [styles.decrementIconsSeparate]: iconPosition === 'separate',
-              [styles.disabled]: disabled,
-            })}
+          className={cn(styles.decrement, {
+            [styles.decrementSmall]: size === 'small',
+            [styles.decrementIconsSeparate]: iconPosition === 'separate',
+            [styles.disabled]: disabled,
+          })}
           onClick={onDecrement}
           kind="transparent"
           data-test="number-field-decrement"
@@ -172,7 +171,19 @@ export const NumberField: FC<NumberFieldProps> = ({
         />
       </>
     )
-  }, [showIconButtons, onIncrement, onDecrement, decrementIconAriaLabel, incrementIconAriaLabel, value, disabled, min, max, size, iconPosition])
+  }, [
+    showIconButtons,
+    onIncrement,
+    onDecrement,
+    decrementIconAriaLabel,
+    incrementIconAriaLabel,
+    value,
+    disabled,
+    min,
+    max,
+    size,
+    iconPosition,
+  ])
 
   const onChangeWrapped = useCallback(
     ({ target: { value: newValue } }: ChangeEvent<HTMLInputElement>) => {
@@ -200,11 +211,15 @@ export const NumberField: FC<NumberFieldProps> = ({
       onChange={onChangeWrapped}
       type="number"
       inputContainerChild={overlay}
-      inputContainerClassName={cn(styles.inputContainer, {
-        [styles.buttons]: showIconButtons,
-        [styles.buttonsIconsSeparate]: iconPosition === 'separate',
-        [styles.buttonsRegularIconsSeparate]: iconPosition === 'separate' && size !== 'small',
-      }, inputContainerClassName)}
+      inputContainerClassName={cn(
+        styles.inputContainer,
+        {
+          [styles.buttons]: showIconButtons,
+          [styles.buttonsIconsSeparate]: iconPosition === 'separate',
+          [styles.buttonsRegularIconsSeparate]: iconPosition === 'separate' && size !== 'small',
+        },
+        inputContainerClassName,
+      )}
       inputClassName={inputClassName}
       disabled={disabled}
       size={size}


### PR DESCRIPTION
### Problem

The tooltip text is illogical. Because in this case, the correct maximum value of 6 must be less than 6 

<img width="396" alt="image" src="https://user-images.githubusercontent.com/135645/148924996-4f55b710-5b80-4763-a70f-61e70bd69342.png">

### Solution

New text:

<img width="431" alt="image" src="https://user-images.githubusercontent.com/135645/148925479-99228588-40c3-43c4-9205-1b7ad20a9d58.png">
