### PR TITLE
Close dropdown menu in SelectField while resizing

### DIFF
--- a/packages/ui/src/Select/MultiSelectField.tsx
+++ b/packages/ui/src/Select/MultiSelectField.tsx
@@ -165,6 +165,22 @@ export const MultiSelectField = <V extends string | number = number>(props: Mult
     }
   }, [menuIsOpen])
 
+  /** If the size of screen is changed we close dropdown menu to aviod the dropdown menu bug in react-select library.
+   * For more information visit: https://github.com/JedWatson/react-select/issues/3533
+   */
+  useEffect(() => {
+    const handleResize = () => {
+      if (selectRef.current) {
+        selectRef.current.blur()
+      }
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    /** Clean up established event listeners before creating new ones */
+    return () => window.removeEventListener('resize', handleResize)
+  })
+
   const selectProps: ReactSelectProps<SelectFieldOption<V>> = {
     ref: selectRef,
     inputId: id,

--- a/packages/ui/src/Select/SelectField.tsx
+++ b/packages/ui/src/Select/SelectField.tsx
@@ -135,6 +135,22 @@ export const SelectField = <V extends string | number = string>(props: SelectFie
     }
   }, [menuIsOpen])
 
+  /** If the size of screen is changed we close dropdown menu to aviod the dropdown menu bug in react-select library.
+   * For more information visit: https://github.com/JedWatson/react-select/issues/3533
+   */
+  useEffect(() => {
+    const handleResize = () => {
+      if (selectRef.current) {
+        selectRef.current.blur()
+      }
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    /** Clean up established event listeners before creating new ones */
+    return () => window.removeEventListener('resize', handleResize)
+  })
+
   const innerComponents = useMemo(
     () =>
       singleValueTooltipVisible


### PR DESCRIPTION
- Dropdown menu is misplaced in SelectField while resizing. 
- It is stem from the react-select library issue
- For more information visit https://github.com/JedWatson/react-select/issues/3533