### PR TITLE
MC-2117 Watch column size and page size changes

### DIFF
--- a/packages/ui/src/Table/Table.tsx
+++ b/packages/ui/src/Table/Table.tsx
@@ -29,6 +29,7 @@ import {
   useColumnOrder,
   useExpanded,
   TableInstance,
+  TableState,
 } from 'react-table'
 import { AlertTriangle, ChevronDown, ChevronUp } from 'react-feather'
 
@@ -45,6 +46,7 @@ import { TableContent } from './TableContent'
 import { ROW_EXPANDER_COLUMN_ID } from './constants'
 import { useColumnsSelection, ContextMenu } from './features/columnsSelection'
 import { useRefValue } from '../hooks'
+import { useDebouncedEffect } from '../hooks/useDebouncedEffect'
 
 import styles from './Table.module.scss'
 import styleConsts from '../../styles/constants/export.module.scss'
@@ -216,6 +218,7 @@ type CustomTableProps<D extends object> = {
   children?: (table: ReactElement, tableInstance: TableInstance<D>) => ReactElement
   renderRowSubComponent?: (props: RowType<D>) => ReactNode
   onCopy?: (data: (string | undefined)[][]) => void
+  onTableStateChange?: (state: Pick<TableState<D>, 'columnResizing' | 'pageSize'>) => void
 } & CustomTableRowClickProps<D> &
   DataTestProp
 
@@ -282,6 +285,7 @@ export const Table = <D extends object>({
   renderRowSubComponent,
   autoResetExpanded = false,
   onCopy,
+  onTableStateChange,
 }: TableProps<D>): ReactElement => {
   const getOncopy = useRefValue(onCopy)
   const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null)
@@ -421,6 +425,12 @@ export const Table = <D extends object>({
     }),
     [onKeyUp],
   )
+
+  useDebouncedEffect(() => {
+    if (onTableStateChange) {
+      onTableStateChange({ pageSize, columnResizing })
+    }
+  }, [pageSize, columnResizing])
 
   useEffect(() => {
     return () => {

--- a/packages/ui/src/hooks/useDebouncedEffect.ts
+++ b/packages/ui/src/hooks/useDebouncedEffect.ts
@@ -1,0 +1,24 @@
+import { DependencyList, useEffect, useState } from 'react'
+
+export const useDebouncedEffect = <T>(effect: () => T, deps: DependencyList, delay = 200) => {
+  const [timer, setTimer] = useState<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    if (timer) {
+      clearTimeout(timer)
+    }
+
+    const newTimer = setTimeout(() => {
+      effect()
+    }, delay)
+
+    setTimer(newTimer)
+
+    return () => {
+      if (timer) {
+        clearTimeout(timer)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps)
+}


### PR DESCRIPTION
Management Center has to keep track of column resizing and page size selection. That's why, the changes in `pageSize` and `columnResizing` will be passed to the callback, obtained from MC.
Also, to prevent exhaustive calls to the passed callback, I added `useDebouncedEffect`, which calls the effect function once in minimum of 200ms. The delay is configurable.