### PR TITLE
Add permanent placeholder for checkable select field

### DIFF
--- a/packages/ui/src/Select/CheckableSelectField.module.scss
+++ b/packages/ui/src/Select/CheckableSelectField.module.scss
@@ -8,6 +8,10 @@
 .opener {
   input {
     cursor: pointer;
+
+    &.withPermanentPlaceholder {
+      color: c.$colorTextSecondary;
+    }
   }
 }
 

--- a/packages/ui/src/Select/CheckableSelectField.tsx
+++ b/packages/ui/src/Select/CheckableSelectField.tsx
@@ -21,6 +21,7 @@ export type CheckableSelectFieldCoreStaticProps<V> = {
   onChange: (newValue: V[]) => void
   allSelectedLabel?: string
   noneSelectedLabel?: string
+  permanentPlaceholder?: string
 }
 
 export type CheckableSelectFieldExtraProps<V> = {
@@ -73,6 +74,7 @@ export const CheckableSelectField = <V extends string | number = number>(props: 
     'data-test': dataTest,
     allSelectedLabel = 'All selected',
     noneSelectedLabel = 'None selected',
+    permanentPlaceholder,
     noOptionsMessage = 'No options',
     id: rootId,
   } = props
@@ -99,6 +101,9 @@ export const CheckableSelectField = <V extends string | number = number>(props: 
   }, [options, searchValue])
 
   const getValueLabel = () => {
+    if (permanentPlaceholder) {
+      return permanentPlaceholder
+    }
     if (value.length === 0) {
       return noneSelectedLabel
     }
@@ -123,7 +128,9 @@ export const CheckableSelectField = <V extends string | number = number>(props: 
         disabled={disabled}
         showAriaLabel={showAriaLabel}
         helperText={helperText}
-        className={cls(className, styles.opener)}
+        className={cls(className, styles.opener, {
+          [styles.withPermanentPlaceholder]: !!permanentPlaceholder,
+        })}
         error={error}
         onBlur={onBlur}
         readOnly


### PR DESCRIPTION
<img width="842" alt="Screenshot 2023-11-09 at 18 05 05" src="https://github.com/hazelcast/hive/assets/75899391/4d711417-bbd4-4e38-826f-2baa93f8a844">

We want to use placeholder text instead of label sometimes.
Currently, we have a control over placeholder text when all options or no options are selected. This PR is to extend this control also for the situation when we have some options selected.
This is especially useful when we don't have so many options. In this case, it's obvious that how many items are selected.