### PR TITLE
Avoid overflow of a long text value inside SelectField in Firefox [MC-2784]

### DIFF
--- a/packages/ui/src/Select/SelectField.module.scss
+++ b/packages/ui/src/Select/SelectField.module.scss
@@ -6,7 +6,6 @@ $menuMargin: c.$grid * 3;
 $selectContainer: ':global .hz-select-field';
 $selectControl: ':global .hz-select-field__control';
 $selectValueContainer: ':global .hz-select-field__value-container';
-$selectSingleValue: ':global .hz-select-field__single-value';
 $selectMenuPortal: ':global .hz-select-field__menu-portal';
 $selectMenu: ':global .hz-select-field__menu';
 $selectMenuList: ':global .hz-select-field__menu-list';
@@ -32,16 +31,13 @@ $selectGroupHeading: ':global .hz-select-field__group-heading';
 
   #{$selectContainer} {
     flex: 1 1 auto;
+    max-width: 100%;
 
     @include c.typographyBodySmall;
   }
 
   #{$selectValueContainer} {
     padding: c.$grid * 1.375 0;
-
-    #{$selectSingleValue} {
-      position: absolute;
-    }
   }
 
   #{$selectControl} {

--- a/packages/ui/src/Select/SelectField.module.scss
+++ b/packages/ui/src/Select/SelectField.module.scss
@@ -6,6 +6,7 @@ $menuMargin: c.$grid * 3;
 $selectContainer: ':global .hz-select-field';
 $selectControl: ':global .hz-select-field__control';
 $selectValueContainer: ':global .hz-select-field__value-container';
+$selectSingleValue: ':global .hz-select-field__single-value';
 $selectMenuPortal: ':global .hz-select-field__menu-portal';
 $selectMenu: ':global .hz-select-field__menu';
 $selectMenuList: ':global .hz-select-field__menu-list';
@@ -37,6 +38,10 @@ $selectGroupHeading: ':global .hz-select-field__group-heading';
 
   #{$selectValueContainer} {
     padding: c.$grid * 1.375 0;
+
+    #{$selectSingleValue} {
+      position: absolute;
+    }
   }
 
   #{$selectControl} {


### PR DESCRIPTION
After upgrading to react-select to v5.8.0 from v4.3.1, select field values with long text started to overflow from the container. Restricted the maximum width to 100%.
There is a related [issue](https://github.com/JedWatson/react-select/issues/5170), but no one seems interested :)  