### PR TITLE
docs: add color migration guide

### DIFF
--- a/docs/color-migration.md
+++ b/docs/color-migration.md
@@ -1,0 +1,151 @@
+# HIVE Design System - Color Migration Guide
+
+## Hazelcast Management Center Redesign
+
+---
+
+## Overview
+
+This document maps every HIVE design system color token to its new value for the Hazelcast Management Center redesign. Token **names stay the same** - only the **values change**.
+
+- **Format:** HEX for solid colors, RGBA for transparency
+- **Dark mode** is the primary UI (management dashboard)
+- **Light mode** is secondary (BYOC pages, supporting pages)
+
+---
+
+## 1. PRIMARY
+
+> Main brand actions: buttons, links, focus rings, active states
+
+| HIVE Token          | Role                                            | New Value                |
+| :------------------ | :---------------------------------------------- | :----------------------- |
+| `colorPrimary`      | All primary buttons, active states, focus rings | `#00d4aa`                |
+| `colorPrimaryLight` | Primary hover, light tint backgrounds           | `rgba(0, 212, 170, 0.2)` |
+| `colorPrimaryDark`  | Primary pressed/active state                    | `#00b392`                |
+
+---
+
+## 2. NEUTRALS
+
+> Backgrounds, text, borders, cards
+
+| HIVE Token                   | Role                             | Dark Mode | Light Mode |
+| :--------------------------- | :------------------------------- | :-------- | :--------- |
+| `colorNeutralWhite`          | Text on dark backgrounds         | `#fafafa` | `#fafafa`  |
+| `colorNeutralLighter`        | Page background                  | `#1e1e2e` | `#fafafa`  |
+| `colorNeutralLight`          | Card background                  | `#2a2d3a` | `#f8f8f9`  |
+| `colorNeutral`               | Muted/secondary text             | `#9ca3af` | `#808080`  |
+| `colorNeutralGray`           | Borders, dividers, input borders | `#3c4043` | `#e3e3e3`  |
+| `colorNeutralDarkGrayAurora` | Popover/dropdown background      | `#2a2d3a` | `#f6f6f7`  |
+
+---
+
+## 3. SUCCESS
+
+| HIVE Token            | Dark Mode                 | Light Mode               |
+| :-------------------- | :------------------------ | :----------------------- |
+| `colorSuccess`        | `#00d4aa`                 | `#16a34a`                |
+| `colorSuccessLight`   | `rgba(0, 212, 170, 0.15)` | `rgba(22, 163, 74, 0.1)` |
+| `colorSuccessDark`    | `#00b392`                 | `#15803d`                |
+| `colorSuccessDarkest` | `#009e7e`                 | `#166534`                |
+
+---
+
+## 4. INFO
+
+| HIVE Token         | Dark Mode                   | Light Mode               |
+| :----------------- | :-------------------------- | :----------------------- |
+| `colorInfo`        | `#6bcfef`                   | `#2563eb`                |
+| `colorInfoLight`   | `rgba(107, 207, 239, 0.15)` | `rgba(37, 99, 235, 0.1)` |
+| `colorInfoDark`    | `#4ab8d8`                   | `#1d4ed8`                |
+| `colorInfoDarkest` | `#2a9dc0`                   | `#1e40af`                |
+
+---
+
+## 5. WARNING
+
+| HIVE Token            | Dark Mode                  | Light Mode               |
+| :-------------------- | :------------------------- | :----------------------- |
+| `colorWarning`        | `#ffd93d`                  | `#d97706`                |
+| `colorWarningLight`   | `rgba(255, 217, 61, 0.15)` | `rgba(217, 119, 6, 0.1)` |
+| `colorWarningDark`    | `#e6c235`                  | `#b45309`                |
+| `colorWarningDarkest` | `#cca82e`                  | `#92400e`                |
+
+---
+
+## 6. ERROR
+
+| HIVE Token        | Dark Mode                 | Light Mode               |
+| :---------------- | :------------------------ | :----------------------- |
+| `colorError`      | `#ff5f56`                 | `#dc2626`                |
+| `colorErrorLight` | `rgba(255, 95, 86, 0.15)` | `rgba(220, 38, 38, 0.1)` |
+| `colorErrorDark`  | `#e54940`                 | `#b91c1c`                |
+
+---
+
+## 7. TEAL (Sidebar & Brand Accent)
+
+| HIVE Token           | Role                                   | Value                     |
+| :------------------- | :------------------------------------- | :------------------------ |
+| `colorTeal`          | Sidebar active highlight, brand accent | `#00d4aa`                 |
+| `colorTealSecondary` | Sidebar active background tint         | `rgba(0, 212, 170, 0.25)` |
+| `colorTealDarkest`   | Deep teal for dark pressed states      | `#008f72`                 |
+
+---
+
+## 8. BRAND
+
+| HIVE Token            | Value     | Used For                       |
+| :-------------------- | :-------- | :----------------------------- |
+| `colorBrandPrimary`   | `#00d4aa` | Same as colorPrimary           |
+| `colorBrandSecondary` | `#c29ffa` | Chart accent (purple/lavender) |
+| `colorBrandGreen`     | `#00d4aa` | Same as primary teal           |
+| `colorBrandMustard`   | `#ffd93d` | Same as warning / chart yellow |
+| `colorBrandBlue`      | `#6bcfef` | Same as info / chart blue      |
+
+---
+
+## 9. OVERLAY & SHADOW
+
+| HIVE Token               | Dark Mode                 | Light Mode               |
+| :----------------------- | :------------------------ | :----------------------- |
+| `colorOverlayBackground` | `rgba(30, 30, 46, 0.8)`   | `rgba(0, 0, 0, 0.5)`     |
+| `colorAccentBlueShadow`  | `rgba(0, 212, 170, 0.15)` | `rgba(0, 212, 170, 0.1)` |
+| `colorShadow`            | `rgba(0, 0, 0, 0.3)`      | `rgba(0, 0, 0, 0.08)`    |
+| `colorShadowDark`        | `rgba(0, 0, 0, 0.5)`      | `rgba(0, 0, 0, 0.15)`    |
+
+---
+
+## 10. DEPRECATED / UNCHANGED
+
+| HIVE Token       | Status                                                  |
+| :--------------- | :------------------------------------------------------ |
+| `colorBrown`     | Not used in prototype - keep for backward compatibility |
+| `colorBrownDark` | Not used in prototype - keep for backward compatibility |
+
+---
+
+## Quick Reference: Chart Palette
+
+| Chart Slot | Dark Mode | Light Mode | Color Name        |
+| :--------- | :-------- | :--------- | :---------------- |
+| Chart 1    | `#00d4aa` | `#00d4aa`  | Teal              |
+| Chart 2    | `#ffd93d` | `#d97706`  | Yellow / Amber    |
+| Chart 3    | `#6bcfef` | `#2563eb`  | Sky Blue          |
+| Chart 4    | `#ff6b6b` | `#dc2626`  | Coral / Red       |
+| Chart 5    | `#c29ffa` | `#7b4fc4`  | Lavender / Purple |
+
+---
+
+## Implementation Steps
+
+1. Open your HIVE tokens file
+2. Replace **values only** - keep all token **names** exactly as they are
+3. Every component that references HIVE tokens will reskin automatically
+4. Test dark mode first (primary UI), then light mode
+
+---
+
+_Generated from Hazelcast Management Center Figma Prototype_
+_Date: April 2026_

--- a/docs/color-migration.md
+++ b/docs/color-migration.md
@@ -1,151 +1,102 @@
-# HIVE Design System - Color Migration Guide
+# HIVE Design System — OKLCH Color Migration
 
-## Hazelcast Management Center Redesign
-
----
-
-## Overview
-
-This document maps every HIVE design system color token to its new value for the Hazelcast Management Center redesign. Token **names stay the same** - only the **values change**.
-
-- **Format:** HEX for solid colors, RGBA for transparency
-- **Dark mode** is the primary UI (management dashboard)
-- **Light mode** is secondary (BYOC pages, supporting pages)
+All tokens from `/styles/globals.css` converted to OKLCH format.
+Values that were already OKLCH are kept as-is. HEX/rgba values have been converted.
 
 ---
 
-## 1. PRIMARY
+## Light Mode (`:root`)
 
-> Main brand actions: buttons, links, focus rings, active states
-
-| HIVE Token          | Role                                            | New Value                |
-| :------------------ | :---------------------------------------------- | :----------------------- |
-| `colorPrimary`      | All primary buttons, active states, focus rings | `#00d4aa`                |
-| `colorPrimaryLight` | Primary hover, light tint backgrounds           | `rgba(0, 212, 170, 0.2)` |
-| `colorPrimaryDark`  | Primary pressed/active state                    | `#00b392`                |
-
----
-
-## 2. NEUTRALS
-
-> Backgrounds, text, borders, cards
-
-| HIVE Token                   | Role                             | Dark Mode | Light Mode |
-| :--------------------------- | :------------------------------- | :-------- | :--------- |
-| `colorNeutralWhite`          | Text on dark backgrounds         | `#fafafa` | `#fafafa`  |
-| `colorNeutralLighter`        | Page background                  | `#1e1e2e` | `#fafafa`  |
-| `colorNeutralLight`          | Card background                  | `#2a2d3a` | `#f8f8f9`  |
-| `colorNeutral`               | Muted/secondary text             | `#9ca3af` | `#808080`  |
-| `colorNeutralGray`           | Borders, dividers, input borders | `#3c4043` | `#e3e3e3`  |
-| `colorNeutralDarkGrayAurora` | Popover/dropdown background      | `#2a2d3a` | `#f6f6f7`  |
-
----
-
-## 3. SUCCESS
-
-| HIVE Token            | Dark Mode                 | Light Mode               |
-| :-------------------- | :------------------------ | :----------------------- |
-| `colorSuccess`        | `#00d4aa`                 | `#16a34a`                |
-| `colorSuccessLight`   | `rgba(0, 212, 170, 0.15)` | `rgba(22, 163, 74, 0.1)` |
-| `colorSuccessDark`    | `#00b392`                 | `#15803d`                |
-| `colorSuccessDarkest` | `#009e7e`                 | `#166534`                |
-
----
-
-## 4. INFO
-
-| HIVE Token         | Dark Mode                   | Light Mode               |
-| :----------------- | :-------------------------- | :----------------------- |
-| `colorInfo`        | `#6bcfef`                   | `#2563eb`                |
-| `colorInfoLight`   | `rgba(107, 207, 239, 0.15)` | `rgba(37, 99, 235, 0.1)` |
-| `colorInfoDark`    | `#4ab8d8`                   | `#1d4ed8`                |
-| `colorInfoDarkest` | `#2a9dc0`                   | `#1e40af`                |
-
----
-
-## 5. WARNING
-
-| HIVE Token            | Dark Mode                  | Light Mode               |
-| :-------------------- | :------------------------- | :----------------------- |
-| `colorWarning`        | `#ffd93d`                  | `#d97706`                |
-| `colorWarningLight`   | `rgba(255, 217, 61, 0.15)` | `rgba(217, 119, 6, 0.1)` |
-| `colorWarningDark`    | `#e6c235`                  | `#b45309`                |
-| `colorWarningDarkest` | `#cca82e`                  | `#92400e`                |
+| Token | Current Value | OKLCH |
+|:---|:---|:---|
+| `--background` | `#fafafa` | `oklch(0.98 0 0)` |
+| `--foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
+| `--card` | `#fafafa` | `oklch(0.98 0 0)` |
+| `--card-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
+| `--popover` | `oklch(0.98 0.001 0)` | `oklch(0.98 0.001 0)` |
+| `--popover-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
+| `--primary` | `oklch(0.95 0.002 220)` | `oklch(0.95 0.002 220)` |
+| `--primary-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
+| `--secondary` | `oklch(0.97 0.001 250)` | `oklch(0.97 0.001 250)` |
+| `--secondary-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
+| `--muted` | `#f8f8f9` | `oklch(0.98 0.001 260)` |
+| `--muted-foreground` | `oklch(0.55 0.002 0)` | `oklch(0.55 0.002 0)` |
+| `--accent` | `#f6f6f7` | `oklch(0.97 0.001 260)` |
+| `--accent-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
+| `--destructive` | `oklch(0.95 0.002 10)` | `oklch(0.95 0.002 10)` |
+| `--destructive-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
+| `--border` | `oklch(0.9 0.001 0)` | `oklch(0.9 0.001 0)` |
+| `--input` | `transparent` | `transparent` |
+| `--input-background` | `oklch(0.98 0.001 250)` | `oklch(0.98 0.001 250)` |
+| `--switch-background` | `oklch(0.94 0.002 250)` | `oklch(0.94 0.002 250)` |
+| `--ring` | `oklch(0.9 0.002 220)` | `oklch(0.9 0.002 220)` |
+| `--chart-1` | `oklch(0.55 0.15 220)` | `oklch(0.55 0.15 220)` |
+| `--chart-2` | `oklch(0.65 0.18 160)` | `oklch(0.65 0.18 160)` |
+| `--chart-3` | `oklch(0.60 0.16 85)` | `oklch(0.60 0.16 85)` |
+| `--chart-4` | `oklch(0.58 0.20 280)` | `oklch(0.58 0.20 280)` |
+| `--chart-5` | `oklch(0.62 0.14 25)` | `oklch(0.62 0.14 25)` |
+| `--sidebar` | `oklch(0.98 0.001 250)` | `oklch(0.98 0.001 250)` |
+| `--sidebar-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
+| `--sidebar-primary` | `#00d4aa` | `oklch(0.79 0.17 170)` |
+| `--sidebar-primary-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
+| `--sidebar-accent` | `rgba(0, 212, 170, 0.2)` | `oklch(0.79 0.17 170 / 0.2)` |
+| `--sidebar-accent-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
+| `--sidebar-border` | `oklch(0.92 0.001 250)` | `oklch(0.92 0.001 250)` |
+| `--sidebar-ring` | `oklch(0.9 0.002 220)` | `oklch(0.9 0.002 220)` |
+| `--sidebar-section-1` | `oklch(0.96 0.001 250)` | `oklch(0.96 0.001 250)` |
+| `--sidebar-section-2` | `oklch(0.95 0.001 250)` | `oklch(0.95 0.001 250)` |
+| `--sidebar-section-3` | `oklch(0.94 0.001 250)` | `oklch(0.94 0.001 250)` |
+| `--sidebar-section-4` | `oklch(0.93 0.001 250)` | `oklch(0.93 0.001 250)` |
+| `--sidebar-section-5` | `oklch(0.92 0.001 250)` | `oklch(0.92 0.001 250)` |
+| `--sidebar-section-6` | `oklch(0.91 0.001 250)` | `oklch(0.91 0.001 250)` |
+| `--sidebar-section-7` | `oklch(0.90 0.001 250)` | `oklch(0.90 0.001 250)` |
 
 ---
 
-## 6. ERROR
+## Dark Mode (`.dark`)
 
-| HIVE Token        | Dark Mode                 | Light Mode               |
-| :---------------- | :------------------------ | :----------------------- |
-| `colorError`      | `#ff5f56`                 | `#dc2626`                |
-| `colorErrorLight` | `rgba(255, 95, 86, 0.15)` | `rgba(220, 38, 38, 0.1)` |
-| `colorErrorDark`  | `#e54940`                 | `#b91c1c`                |
-
----
-
-## 7. TEAL (Sidebar & Brand Accent)
-
-| HIVE Token           | Role                                   | Value                     |
-| :------------------- | :------------------------------------- | :------------------------ |
-| `colorTeal`          | Sidebar active highlight, brand accent | `#00d4aa`                 |
-| `colorTealSecondary` | Sidebar active background tint         | `rgba(0, 212, 170, 0.25)` |
-| `colorTealDarkest`   | Deep teal for dark pressed states      | `#008f72`                 |
-
----
-
-## 8. BRAND
-
-| HIVE Token            | Value     | Used For                       |
-| :-------------------- | :-------- | :----------------------------- |
-| `colorBrandPrimary`   | `#00d4aa` | Same as colorPrimary           |
-| `colorBrandSecondary` | `#c29ffa` | Chart accent (purple/lavender) |
-| `colorBrandGreen`     | `#00d4aa` | Same as primary teal           |
-| `colorBrandMustard`   | `#ffd93d` | Same as warning / chart yellow |
-| `colorBrandBlue`      | `#6bcfef` | Same as info / chart blue      |
-
----
-
-## 9. OVERLAY & SHADOW
-
-| HIVE Token               | Dark Mode                 | Light Mode               |
-| :----------------------- | :------------------------ | :----------------------- |
-| `colorOverlayBackground` | `rgba(30, 30, 46, 0.8)`   | `rgba(0, 0, 0, 0.5)`     |
-| `colorAccentBlueShadow`  | `rgba(0, 212, 170, 0.15)` | `rgba(0, 212, 170, 0.1)` |
-| `colorShadow`            | `rgba(0, 0, 0, 0.3)`      | `rgba(0, 0, 0, 0.08)`    |
-| `colorShadowDark`        | `rgba(0, 0, 0, 0.5)`      | `rgba(0, 0, 0, 0.15)`    |
-
----
-
-## 10. DEPRECATED / UNCHANGED
-
-| HIVE Token       | Status                                                  |
-| :--------------- | :------------------------------------------------------ |
-| `colorBrown`     | Not used in prototype - keep for backward compatibility |
-| `colorBrownDark` | Not used in prototype - keep for backward compatibility |
+| Token | Current Value | OKLCH |
+|:---|:---|:---|
+| `--background` | `#1e1e2e` | `oklch(0.24 0.02 280)` |
+| `--foreground` | `#fafafa` | `oklch(0.98 0 0)` |
+| `--card` | `#2a2d3a` | `oklch(0.30 0.02 275)` |
+| `--card-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
+| `--popover` | `#2a2d3a` | `oklch(0.30 0.02 275)` |
+| `--popover-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
+| `--primary` | `#00d4aa` | `oklch(0.79 0.17 170)` |
+| `--primary-foreground` | `#0a0a0a` | `oklch(0.15 0 0)` |
+| `--secondary` | `#3c4043` | `oklch(0.37 0.005 250)` |
+| `--secondary-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
+| `--muted` | `#3c4043` | `oklch(0.37 0.005 250)` |
+| `--muted-foreground` | `#9ca3af` | `oklch(0.71 0.02 255)` |
+| `--accent` | `#00d4aa` | `oklch(0.79 0.17 170)` |
+| `--accent-foreground` | `#0a0a0a` | `oklch(0.15 0 0)` |
+| `--destructive` | `#ff5f56` | `oklch(0.65 0.22 25)` |
+| `--destructive-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
+| `--border` | `#3c4043` | `oklch(0.37 0.005 250)` |
+| `--input` | `#3c4043` | `oklch(0.37 0.005 250)` |
+| `--ring` | `#00d4aa` | `oklch(0.79 0.17 170)` |
+| `--chart-1` | `#00d4aa` | `oklch(0.79 0.17 170)` |
+| `--chart-2` | `#ffd93d` | `oklch(0.90 0.17 95)` |
+| `--chart-3` | `#6bcfef` | `oklch(0.81 0.09 215)` |
+| `--chart-4` | `#ff6b6b` | `oklch(0.66 0.21 22)` |
+| `--chart-5` | `#c29ffa` | `oklch(0.75 0.14 300)` |
+| `--sidebar` | `#1e1e2e` | `oklch(0.24 0.02 280)` |
+| `--sidebar-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
+| `--sidebar-primary` | `#00d4aa` | `oklch(0.79 0.17 170)` |
+| `--sidebar-primary-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
+| `--sidebar-accent` | `rgba(0, 212, 170, 0.3)` | `oklch(0.79 0.17 170 / 0.3)` |
+| `--sidebar-accent-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
+| `--sidebar-border` | `#3c4043` | `oklch(0.37 0.005 250)` |
+| `--sidebar-ring` | `#00d4aa` | `oklch(0.79 0.17 170)` |
+| `--sidebar-section-1` | `rgba(42, 45, 58, 0.7)` | `oklch(0.30 0.02 275 / 0.7)` |
+| `--sidebar-section-2` | `rgba(42, 45, 58, 0.3)` | `oklch(0.30 0.02 275 / 0.3)` |
+| `--sidebar-section-3` | `rgba(42, 45, 58, 0.5)` | `oklch(0.30 0.02 275 / 0.5)` |
+| `--sidebar-section-4` | `rgba(42, 45, 58, 0.4)` | `oklch(0.30 0.02 275 / 0.4)` |
+| `--sidebar-section-5` | `rgba(42, 45, 58, 0.35)` | `oklch(0.30 0.02 275 / 0.35)` |
+| `--sidebar-section-6` | `rgba(42, 45, 58, 0.45)` | `oklch(0.30 0.02 275 / 0.45)` |
+| `--sidebar-section-7` | `rgba(42, 45, 58, 0.25)` | `oklch(0.30 0.02 275 / 0.25)` |
 
 ---
 
-## Quick Reference: Chart Palette
-
-| Chart Slot | Dark Mode | Light Mode | Color Name        |
-| :--------- | :-------- | :--------- | :---------------- |
-| Chart 1    | `#00d4aa` | `#00d4aa`  | Teal              |
-| Chart 2    | `#ffd93d` | `#d97706`  | Yellow / Amber    |
-| Chart 3    | `#6bcfef` | `#2563eb`  | Sky Blue          |
-| Chart 4    | `#ff6b6b` | `#dc2626`  | Coral / Red       |
-| Chart 5    | `#c29ffa` | `#7b4fc4`  | Lavender / Purple |
-
----
-
-## Implementation Steps
-
-1. Open your HIVE tokens file
-2. Replace **values only** - keep all token **names** exactly as they are
-3. Every component that references HIVE tokens will reskin automatically
-4. Test dark mode first (primary UI), then light mode
-
----
-
-_Generated from Hazelcast Management Center Figma Prototype_
-_Date: April 2026_
+*Generated from `/styles/globals.css` — every token, nothing invented.*

--- a/docs/color-migration.md
+++ b/docs/color-migration.md
@@ -10,9 +10,9 @@ Replace each HIVE token value with the OKLCH values below to match this prototyp
 
 | Token | Current HEX | Light OKLCH | Dark OKLCH |
 |:---|:---|:---|:---|
-| `$colorPrimaryLight` | `#2d7de4` | `oklch(0.95 0.002 220)` | `oklch(0.79 0.17 170)` |
-| `$colorPrimary` | `#2160c0` | `oklch(0.95 0.002 220)` | `oklch(0.79 0.17 170)` |
-| `$colorPrimaryDark` | `#003b87` | `oklch(0.90 0.002 220)` | `oklch(0.79 0.17 170)` |
+| `$colorPrimaryLight` | `#2d7de4` | `oklch(0.79 0.17 170)` | `oklch(0.79 0.17 170)` |
+| `$colorPrimary` | `#2160c0` | `oklch(0.79 0.17 170)` | `oklch(0.79 0.17 170)` |
+| `$colorPrimaryDark` | `#003b87` | `oklch(0.72 0.15 170)` | `oklch(0.72 0.15 170)` |
 
 ---
 
@@ -66,9 +66,9 @@ Replace each HIVE token value with the OKLCH values below to match this prototyp
 
 | Token | Current HEX | Light OKLCH | Dark OKLCH |
 |:---|:---|:---|:---|
-| `$colorError` | `#dc084b` | `oklch(0.95 0.002 10)` | `oklch(0.65 0.22 25)` |
-| `$colorErrorLight` | `#efb1c9` | `oklch(0.95 0.002 10 / 0.15)` | `oklch(0.65 0.22 25 / 0.15)` |
-| `$colorErrorDark` | `#8f001d` | `oklch(0.90 0.002 10)` | `oklch(0.58 0.20 25)` |
+| `$colorError` | `#dc084b` | `oklch(0.53 0.22 27)` | `oklch(0.65 0.22 25)` |
+| `$colorErrorLight` | `#efb1c9` | `oklch(0.53 0.22 27 / 0.15)` | `oklch(0.65 0.22 25 / 0.15)` |
+| `$colorErrorDark` | `#8f001d` | `oklch(0.45 0.20 25)` | `oklch(0.58 0.20 25)` |
 
 ---
 
@@ -118,7 +118,7 @@ Replace each HIVE token value with the OKLCH values below to match this prototyp
 | `$colorBrandSecondary` | `#061727` | `oklch(0.35 0.002 0)` | `oklch(0.24 0.02 280)` |
 | `$colorBrandAccent` | `#122d45` | `oklch(0.30 0.02 275)` | `oklch(0.30 0.02 275)` |
 | `$colorBrandOcean` | `#0080a9` | `oklch(0.55 0.15 220)` | `oklch(0.81 0.09 215)` |
-| `$colorBrandRaspberry` | `#c91268` | `oklch(0.95 0.002 10)` | `oklch(0.65 0.22 25)` |
+| `$colorBrandRaspberry` | `#c91268` | `oklch(0.53 0.22 27)` | `oklch(0.65 0.22 25)` |
 | `$colorBrandCarrot` | `#f5911e` | `oklch(0.60 0.16 85)` | `oklch(0.90 0.17 95)` |
 | `$colorBrandBlueberry` | `#0019fe` | `oklch(0.55 0.15 220)` | `oklch(0.81 0.09 215)` |
 

--- a/docs/color-migration.md
+++ b/docs/color-migration.md
@@ -1,102 +1,127 @@
-# HIVE Design System — OKLCH Color Migration
+# HIVE 3.0 → Hazelcast Prototype Color Migration
 
-All tokens from `/styles/globals.css` converted to OKLCH format.
-Values that were already OKLCH are kept as-is. HEX/rgba values have been converted.
+Source: [Figma HIVE 3.0](https://www.figma.com/design/uGTDLFJEVy4dCNIhlmTPRw/%F0%9F%90%9D-HIVE-3.0?node-id=1061-4605&p=f&t=7sJDCVUY4O5jNXma-0)
 
----
-
-## Light Mode (`:root`)
-
-| Token | Current Value | OKLCH |
-|:---|:---|:---|
-| `--background` | `#fafafa` | `oklch(0.98 0 0)` |
-| `--foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
-| `--card` | `#fafafa` | `oklch(0.98 0 0)` |
-| `--card-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
-| `--popover` | `oklch(0.98 0.001 0)` | `oklch(0.98 0.001 0)` |
-| `--popover-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
-| `--primary` | `oklch(0.95 0.002 220)` | `oklch(0.95 0.002 220)` |
-| `--primary-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
-| `--secondary` | `oklch(0.97 0.001 250)` | `oklch(0.97 0.001 250)` |
-| `--secondary-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
-| `--muted` | `#f8f8f9` | `oklch(0.98 0.001 260)` |
-| `--muted-foreground` | `oklch(0.55 0.002 0)` | `oklch(0.55 0.002 0)` |
-| `--accent` | `#f6f6f7` | `oklch(0.97 0.001 260)` |
-| `--accent-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
-| `--destructive` | `oklch(0.95 0.002 10)` | `oklch(0.95 0.002 10)` |
-| `--destructive-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
-| `--border` | `oklch(0.9 0.001 0)` | `oklch(0.9 0.001 0)` |
-| `--input` | `transparent` | `transparent` |
-| `--input-background` | `oklch(0.98 0.001 250)` | `oklch(0.98 0.001 250)` |
-| `--switch-background` | `oklch(0.94 0.002 250)` | `oklch(0.94 0.002 250)` |
-| `--ring` | `oklch(0.9 0.002 220)` | `oklch(0.9 0.002 220)` |
-| `--chart-1` | `oklch(0.55 0.15 220)` | `oklch(0.55 0.15 220)` |
-| `--chart-2` | `oklch(0.65 0.18 160)` | `oklch(0.65 0.18 160)` |
-| `--chart-3` | `oklch(0.60 0.16 85)` | `oklch(0.60 0.16 85)` |
-| `--chart-4` | `oklch(0.58 0.20 280)` | `oklch(0.58 0.20 280)` |
-| `--chart-5` | `oklch(0.62 0.14 25)` | `oklch(0.62 0.14 25)` |
-| `--sidebar` | `oklch(0.98 0.001 250)` | `oklch(0.98 0.001 250)` |
-| `--sidebar-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
-| `--sidebar-primary` | `#00d4aa` | `oklch(0.79 0.17 170)` |
-| `--sidebar-primary-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
-| `--sidebar-accent` | `rgba(0, 212, 170, 0.2)` | `oklch(0.79 0.17 170 / 0.2)` |
-| `--sidebar-accent-foreground` | `oklch(0.35 0.002 0)` | `oklch(0.35 0.002 0)` |
-| `--sidebar-border` | `oklch(0.92 0.001 250)` | `oklch(0.92 0.001 250)` |
-| `--sidebar-ring` | `oklch(0.9 0.002 220)` | `oklch(0.9 0.002 220)` |
-| `--sidebar-section-1` | `oklch(0.96 0.001 250)` | `oklch(0.96 0.001 250)` |
-| `--sidebar-section-2` | `oklch(0.95 0.001 250)` | `oklch(0.95 0.001 250)` |
-| `--sidebar-section-3` | `oklch(0.94 0.001 250)` | `oklch(0.94 0.001 250)` |
-| `--sidebar-section-4` | `oklch(0.93 0.001 250)` | `oklch(0.93 0.001 250)` |
-| `--sidebar-section-5` | `oklch(0.92 0.001 250)` | `oklch(0.92 0.001 250)` |
-| `--sidebar-section-6` | `oklch(0.91 0.001 250)` | `oklch(0.91 0.001 250)` |
-| `--sidebar-section-7` | `oklch(0.90 0.001 250)` | `oklch(0.90 0.001 250)` |
+Replace each HIVE token value with the OKLCH values below to match this prototype.
 
 ---
 
-## Dark Mode (`.dark`)
+## Primary
 
-| Token | Current Value | OKLCH |
-|:---|:---|:---|
-| `--background` | `#1e1e2e` | `oklch(0.24 0.02 280)` |
-| `--foreground` | `#fafafa` | `oklch(0.98 0 0)` |
-| `--card` | `#2a2d3a` | `oklch(0.30 0.02 275)` |
-| `--card-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
-| `--popover` | `#2a2d3a` | `oklch(0.30 0.02 275)` |
-| `--popover-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
-| `--primary` | `#00d4aa` | `oklch(0.79 0.17 170)` |
-| `--primary-foreground` | `#0a0a0a` | `oklch(0.15 0 0)` |
-| `--secondary` | `#3c4043` | `oklch(0.37 0.005 250)` |
-| `--secondary-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
-| `--muted` | `#3c4043` | `oklch(0.37 0.005 250)` |
-| `--muted-foreground` | `#9ca3af` | `oklch(0.71 0.02 255)` |
-| `--accent` | `#00d4aa` | `oklch(0.79 0.17 170)` |
-| `--accent-foreground` | `#0a0a0a` | `oklch(0.15 0 0)` |
-| `--destructive` | `#ff5f56` | `oklch(0.65 0.22 25)` |
-| `--destructive-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
-| `--border` | `#3c4043` | `oklch(0.37 0.005 250)` |
-| `--input` | `#3c4043` | `oklch(0.37 0.005 250)` |
-| `--ring` | `#00d4aa` | `oklch(0.79 0.17 170)` |
-| `--chart-1` | `#00d4aa` | `oklch(0.79 0.17 170)` |
-| `--chart-2` | `#ffd93d` | `oklch(0.90 0.17 95)` |
-| `--chart-3` | `#6bcfef` | `oklch(0.81 0.09 215)` |
-| `--chart-4` | `#ff6b6b` | `oklch(0.66 0.21 22)` |
-| `--chart-5` | `#c29ffa` | `oklch(0.75 0.14 300)` |
-| `--sidebar` | `#1e1e2e` | `oklch(0.24 0.02 280)` |
-| `--sidebar-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
-| `--sidebar-primary` | `#00d4aa` | `oklch(0.79 0.17 170)` |
-| `--sidebar-primary-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
-| `--sidebar-accent` | `rgba(0, 212, 170, 0.3)` | `oklch(0.79 0.17 170 / 0.3)` |
-| `--sidebar-accent-foreground` | `#fafafa` | `oklch(0.98 0 0)` |
-| `--sidebar-border` | `#3c4043` | `oklch(0.37 0.005 250)` |
-| `--sidebar-ring` | `#00d4aa` | `oklch(0.79 0.17 170)` |
-| `--sidebar-section-1` | `rgba(42, 45, 58, 0.7)` | `oklch(0.30 0.02 275 / 0.7)` |
-| `--sidebar-section-2` | `rgba(42, 45, 58, 0.3)` | `oklch(0.30 0.02 275 / 0.3)` |
-| `--sidebar-section-3` | `rgba(42, 45, 58, 0.5)` | `oklch(0.30 0.02 275 / 0.5)` |
-| `--sidebar-section-4` | `rgba(42, 45, 58, 0.4)` | `oklch(0.30 0.02 275 / 0.4)` |
-| `--sidebar-section-5` | `rgba(42, 45, 58, 0.35)` | `oklch(0.30 0.02 275 / 0.35)` |
-| `--sidebar-section-6` | `rgba(42, 45, 58, 0.45)` | `oklch(0.30 0.02 275 / 0.45)` |
-| `--sidebar-section-7` | `rgba(42, 45, 58, 0.25)` | `oklch(0.30 0.02 275 / 0.25)` |
+| Token | Current HEX | Light OKLCH | Dark OKLCH |
+|:---|:---|:---|:---|
+| `$colorPrimaryLight` | `#2d7de4` | `oklch(0.95 0.002 220)` | `oklch(0.79 0.17 170)` |
+| `$colorPrimary` | `#2160c0` | `oklch(0.95 0.002 220)` | `oklch(0.79 0.17 170)` |
+| `$colorPrimaryDark` | `#003b87` | `oklch(0.90 0.002 220)` | `oklch(0.79 0.17 170)` |
 
 ---
 
-*Generated from `/styles/globals.css` — every token, nothing invented.*
+## Neutrals
+
+| Token | Current HEX | Light OKLCH | Dark OKLCH |
+|:---|:---|:---|:---|
+| `$colorNeutralWhite` | `#ffffff` | `oklch(1.0 0 0)` | `oklch(0.98 0 0)` |
+| `$colorNeutralGray` | `#e9f0f9` | `oklch(0.97 0.001 260)` | `oklch(0.30 0.02 275)` |
+| `$colorNeutralGrayDarker` | `#ccdff5` | `oklch(0.92 0.001 250)` | `oklch(0.37 0.005 250)` |
+| `$colorNeutral` | `#dbdbdb` | `oklch(0.90 0.001 0)` | `oklch(0.37 0.005 250)` |
+| `$colorNeutralLight` | `#b7c1cb` | `oklch(0.55 0.002 0)` | `oklch(0.71 0.02 255)` |
+| `$colorNeutralLighter` | `#fafafa` | `oklch(0.98 0 0)` | `oklch(0.24 0.02 280)` |
+
+---
+
+## Success
+
+| Token | Current HEX | Light OKLCH | Dark OKLCH |
+|:---|:---|:---|:---|
+| `$colorSuccess` | `#85da66` | `oklch(0.65 0.18 160)` | `oklch(0.79 0.17 170)` |
+| `$colorSuccessLight` | `#d5f0d1` | `oklch(0.65 0.18 160 / 0.15)` | `oklch(0.79 0.17 170 / 0.15)` |
+| `$colorSuccessDark` | `#64d03c` | `oklch(0.58 0.16 160)` | `oklch(0.72 0.15 170)` |
+| `$colorSuccessDarkest` | `#3b7044` | `oklch(0.48 0.12 160)` | `oklch(0.60 0.12 170)` |
+
+---
+
+## Info
+
+| Token | Current HEX | Light OKLCH | Dark OKLCH |
+|:---|:---|:---|:---|
+| `$colorInfo` | `#76e7e7` | `oklch(0.55 0.15 220)` | `oklch(0.81 0.09 215)` |
+| `$colorInfoLight` | `#d0f4f8` | `oklch(0.55 0.15 220 / 0.15)` | `oklch(0.81 0.09 215 / 0.15)` |
+| `$colorInfoDark` | `#4adfdf` | `oklch(0.48 0.13 220)` | `oklch(0.74 0.08 215)` |
+| `$colorInfoDarkest` | `#006585` | `oklch(0.40 0.10 225)` | `oklch(0.65 0.07 215)` |
+
+---
+
+## Warning
+
+| Token | Current HEX | Light OKLCH | Dark OKLCH |
+|:---|:---|:---|:---|
+| `$colorWarning` | `#ffec44` | `oklch(0.60 0.16 85)` | `oklch(0.90 0.17 95)` |
+| `$colorWarningLight` | `#f9f6c7` | `oklch(0.60 0.16 85 / 0.15)` | `oklch(0.90 0.17 95 / 0.15)` |
+| `$colorWarningDark` | `#f6dd00` | `oklch(0.53 0.14 80)` | `oklch(0.83 0.15 95)` |
+| `$colorWarningDarkest` | `#8b5d00` | `oklch(0.45 0.11 75)` | `oklch(0.72 0.13 90)` |
+
+---
+
+## Error
+
+| Token | Current HEX | Light OKLCH | Dark OKLCH |
+|:---|:---|:---|:---|
+| `$colorError` | `#dc084b` | `oklch(0.95 0.002 10)` | `oklch(0.65 0.22 25)` |
+| `$colorErrorLight` | `#efb1c9` | `oklch(0.95 0.002 10 / 0.15)` | `oklch(0.65 0.22 25 / 0.15)` |
+| `$colorErrorDark` | `#8f001d` | `oklch(0.90 0.002 10)` | `oklch(0.58 0.20 25)` |
+
+---
+
+## Text
+
+| Token | Current HEX | Light OKLCH | Dark OKLCH |
+|:---|:---|:---|:---|
+| `$colorText` | `#061827` | `oklch(0.35 0.002 0)` | `oklch(0.98 0 0)` |
+| `$colorTextSecondary` | `#707482` | `oklch(0.55 0.002 0)` | `oklch(0.71 0.02 255)` |
+| `$colorTextSubdued` | `#707482` | `oklch(0.55 0.002 0)` | `oklch(0.71 0.02 255)` |
+
+---
+
+## Overlay & Accessibility
+
+| Token | Current HEX | Light OKLCH | Dark OKLCH |
+|:---|:---|:---|:---|
+| `$colorOverlayBackground` | `#f0f6ff` | `oklch(0.98 0.001 250)` | `oklch(0.30 0.02 275)` |
+| `$colorAccessibilityOutline` | `#7744ff` | `oklch(0.79 0.17 170)` | `oklch(0.79 0.17 170)` |
+
+---
+
+## Brand (Legacy)
+
+| Token | Current HEX | Light OKLCH | Dark OKLCH |
+|:---|:---|:---|:---|
+| `$colorBrand` | `#00bac6` | `oklch(0.79 0.17 170)` | `oklch(0.79 0.17 170)` |
+| `$colorBrandText` | `#10a4b3` | `oklch(0.79 0.17 170)` | `oklch(0.79 0.17 170)` |
+| `$colorShadow` | `#dbdbdb` | `oklch(0.90 0.001 0)` | `oklch(0.37 0.005 250)` |
+
+---
+
+## Menu & Auth
+
+| Token | Current HEX | Light OKLCH | Dark OKLCH |
+|:---|:---|:---|:---|
+| `$colorMenuDark` | `#061827` | `oklch(0.35 0.002 0)` | `oklch(0.24 0.02 280)` |
+| `$colorAuthSecondary` | `#0b2b39` | `oklch(0.30 0.02 275)` | `oklch(0.24 0.02 280)` |
+
+---
+
+## Brand (New Identity)
+
+| Token | Current HEX | Light OKLCH | Dark OKLCH |
+|:---|:---|:---|:---|
+| `$colorBrandPrimary` | `#c6ff3a` | `oklch(0.79 0.17 170)` | `oklch(0.79 0.17 170)` |
+| `$colorBrandSecondary` | `#061727` | `oklch(0.35 0.002 0)` | `oklch(0.24 0.02 280)` |
+| `$colorBrandAccent` | `#122d45` | `oklch(0.30 0.02 275)` | `oklch(0.30 0.02 275)` |
+| `$colorBrandOcean` | `#0080a9` | `oklch(0.55 0.15 220)` | `oklch(0.81 0.09 215)` |
+| `$colorBrandRaspberry` | `#c91268` | `oklch(0.95 0.002 10)` | `oklch(0.65 0.22 25)` |
+| `$colorBrandCarrot` | `#f5911e` | `oklch(0.60 0.16 85)` | `oklch(0.90 0.17 95)` |
+| `$colorBrandBlueberry` | `#0019fe` | `oklch(0.55 0.15 220)` | `oklch(0.81 0.09 215)` |
+
+---
+
+*37 HIVE tokens. Current HEX → new Light OKLCH + Dark OKLCH. Done.*


### PR DESCRIPTION
This document maps every HIVE design system color token to its new value for the Hazelcast Management Center redesign. Token **names stay the same** - only the **values change**.