### PR TITLE
hzc-7903: Restyle Tabs to HIVE v4

### DIFF
--- a/__stories__/Tabs.mdx
+++ b/__stories__/Tabs.mdx
@@ -1,0 +1,158 @@
+import { Meta, Title, Canvas, Controls } from '@storybook/blocks'
+import * as TabsStories from './Tabs.stories'
+import { DocsTabs } from '../.storybook/DocsTabs'
+
+<Meta of={TabsStories} name="Docs" />
+
+<Title />
+
+Tabs organize related content into a single surface and reveal one panel at a time.
+Use them for peer sections that users switch between frequently.
+
+<DocsTabs tabs={[
+  {
+    id: 'overview',
+    label: 'Overview',
+    content: (
+      <>
+        <Canvas of={TabsStories.Playground} />
+
+        <h2>Basic usage</h2>
+
+        <p>A Tabs group is composed of a <code>TabList</code>, multiple <code>Tab</code> items, and matching <code>TabPanel</code> containers. One tab is active at a time.</p>
+
+        <Canvas of={TabsStories.Basic} />
+
+        <h2>Full width layout</h2>
+
+        <p>The Hive 4.0 design uses a full-width segmented surface. Set <code>fullWidth</code> to stretch tabs evenly across the row.</p>
+
+        <Canvas of={TabsStories.FullWidth} />
+
+        <h2>Navigation tabs</h2>
+
+        <p>Enable <code>navigation</code> when tabs should behave like links and map to routeable URLs.</p>
+
+        <Canvas of={TabsStories.Navigation} />
+
+        <h2>Controlled mode</h2>
+
+        <p>Use <code>TabContextProviderControlled</code> to manage active value from external state (URL params, persisted preferences, or analytics).</p>
+
+        <Canvas of={TabsStories.Controlled} />
+
+        <h2>With icons</h2>
+
+        <p>Icons can support faster recognition but should remain decorative. Labels still carry the meaning.</p>
+
+        <Canvas of={TabsStories.WithIcons} />
+
+        <h2>Custom labels</h2>
+
+        <p>Rich labels are supported, but keep wording short and formatting minimal.</p>
+
+        <Canvas of={TabsStories.CustomLabel} />
+
+        <hr />
+
+        <h2>Visual states</h2>
+
+        <p>QA matrix for checking selected-state styling and panel switching after CSS updates.</p>
+
+        <Canvas of={TabsStories.States} />
+
+        <h2>Legacy v3</h2>
+
+        <p>The v3 Tabs is preserved for gradual migration. Import from <code>@hazelcast/ui/old</code>. New code should use the Tabs above.</p>
+
+        <Canvas of={TabsStories.LegacyV3} />
+
+        <h2>Props</h2>
+
+        <Controls of={TabsStories.Playground} />
+      </>
+    ),
+  },
+  {
+    id: 'guidelines',
+    label: 'Guidelines',
+    content: (
+      <>
+        <h2>Anatomy</h2>
+
+        <p>A Tabs pattern is composed of:</p>
+
+        <ul>
+          <li>a <strong>tab list</strong> container</li>
+          <li>multiple <strong>tab controls</strong></li>
+          <li>one visible <strong>tab panel</strong> at a time</li>
+          <li>a clear <strong>selected state</strong> indicator</li>
+        </ul>
+
+        <h2>When to use tabs</h2>
+
+        <ul>
+          <li>Switching between peer sections in the same context.</li>
+          <li>Comparing related slices of data quickly.</li>
+          <li>Keeping users on one page without route churn.</li>
+        </ul>
+
+        <h3>When not to use tabs</h3>
+
+        <ul>
+          <li>Deep navigation hierarchies.</li>
+          <li>Long, sentence-like labels.</li>
+          <li>Cases where all sections should remain visible together.</li>
+        </ul>
+
+        <h2>Label writing</h2>
+
+        <ul>
+          <li>Use short noun phrases: <code>Overview</code>, <code>Metrics</code>, <code>Settings</code>.</li>
+          <li>Keep labels parallel in tone and grammar.</li>
+          <li>Avoid truncation where possible.</li>
+        </ul>
+
+        <h2>Do &amp; Don&rsquo;t</h2>
+
+        <Canvas of={TabsStories.DoVsDont} />
+      </>
+    ),
+  },
+  {
+    id: 'accessibility',
+    label: 'Accessibility',
+    content: (
+      <>
+        <p>The Tabs implementation follows ARIA roles: <code>tablist</code>, <code>tab</code>, and <code>tabpanel</code>.</p>
+
+        <h2>Naming</h2>
+
+        <p>Set a meaningful <code>ariaLabel</code> on <code>TabList</code>. Each tab label should clearly describe the panel content.</p>
+
+        <h2>Keyboard behavior</h2>
+
+        <ul>
+          <li><code>ArrowLeft</code> and <code>ArrowRight</code> move focus between tabs.</li>
+          <li><code>Home</code> and <code>End</code> jump to first and last tabs.</li>
+          <li><code>Enter</code> and <code>Space</code> activate the focused tab.</li>
+        </ul>
+
+        <p>The component uses manual activation: focus movement does not switch panels until activation keys are pressed.</p>
+
+        <h2>Focus visibility</h2>
+
+        <p>A visible focus indicator is required for keyboard users. Do not remove focus styling.</p>
+
+        <h2>Testing checklist</h2>
+
+        <ul>
+          <li>All tabs are reachable by keyboard.</li>
+          <li>Arrow/Home/End/Enter/Space behaviors work as expected.</li>
+          <li>Only the active panel is rendered visibly.</li>
+          <li>Focus ring remains visible on keyboard focus.</li>
+        </ul>
+      </>
+    ),
+  },
+]} />

--- a/__stories__/Tabs.stories.tsx
+++ b/__stories__/Tabs.stories.tsx
@@ -1,16 +1,124 @@
-import React, { useState } from 'react'
-import { Meta, StoryFn } from '@storybook/react'
+import React, { ReactNode, useState } from 'react'
+import { Meta, StoryObj } from '@storybook/react'
 import { Settings, Info, PenTool } from 'react-feather'
 
 import { TabContextProvider, TabContextProviderControlled } from '../src/components/Tabs/TabContext'
 import { TabList } from '../src/components/Tabs/TabList'
 import { AnchorTabProps, ButtonTabProps, Tab } from '../src/components/Tabs/Tab'
 import { TabPanel } from '../src/components/Tabs/TabPanel'
+import {
+  TabContextProvider as LegacyTabContextProvider,
+  TabList as LegacyTabList,
+  Tab as LegacyTab,
+  TabPanel as LegacyTabPanel,
+} from '../src/old'
 import { Icon } from '../src/components/Icon'
+import s from './Button.stories.module.scss'
 
-type Args = {
+type Story = StoryObj<typeof TabList>
+
+type PlaygroundArgs = {
   fullWidth: boolean
   navigation: boolean
+  tab1: string
+  tab2: string
+  tab3: string
+}
+
+type TabsDemoProps = {
+  fullWidth?: boolean
+  navigation?: boolean
+  labels?: [string, string, string]
+  withIcons?: boolean
+  customLabel?: boolean
+  value?: number
+  onChange?: (value: number) => void
+}
+
+const Caption = ({ children }: { children: ReactNode }) => <div className={s.caption}>{children}</div>
+
+const Cell = ({ label, children }: { label: string; children: ReactNode }) => (
+  <div className={s.cell}>
+    <span className={s.label}>{label}</span>
+    {children}
+  </div>
+)
+
+const TabPanels = ({ labels }: { labels: [string, string, string] }) => (
+  <>
+    <TabPanel value={0}>
+      <p>Content for {labels[0].toLowerCase()}</p>
+    </TabPanel>
+    <TabPanel value={1}>
+      <p>Content for {labels[1].toLowerCase()}</p>
+    </TabPanel>
+    <TabPanel value={2}>
+      <p>Content for {labels[2].toLowerCase()}</p>
+    </TabPanel>
+  </>
+)
+
+const iconByIndex = [Info, PenTool, Settings]
+
+const TabsDemo = ({
+  fullWidth = true,
+  navigation,
+  labels = ['Tab 1', 'Tab 2', 'Tab 3'],
+  withIcons,
+  customLabel,
+  value,
+  onChange,
+}: TabsDemoProps) => {
+  const frameStyle = fullWidth ? ({ width: 1121, maxWidth: '100%', padding: '0 24px', boxSizing: 'border-box' } as const) : undefined
+
+  const tabProps: AnchorTabProps | ButtonTabProps = navigation
+    ? {
+        component: 'a',
+        href: '#',
+      }
+    : {}
+
+  const content = (
+    <>
+      <TabList ariaLabel="Tabs demo">
+        {labels.map((label, idx) => {
+          const icon = iconByIndex[idx] ?? Settings
+          return (
+            <Tab key={label} ariaLabel={label} value={idx} {...tabProps}>
+              {withIcons ? <Icon icon={icon} size="small" ariaLabel={label} /> : null}
+              {customLabel ? (
+                <>
+                  <strong>{label.split(' ')[0]}</strong> {idx + 1}
+                </>
+              ) : (
+                label
+              )}
+            </Tab>
+          )
+        })}
+      </TabList>
+      <TabPanels labels={labels} />
+    </>
+  )
+
+  if (typeof value === 'number' && onChange) {
+    return (
+      <TabContextProviderControlled value={value} onChange={onChange} fullWidth={fullWidth}>
+        <div style={frameStyle}>{content}</div>
+      </TabContextProviderControlled>
+    )
+  }
+
+  return (
+    <TabContextProvider fullWidth={fullWidth}>
+      <div style={frameStyle}>{content}</div>
+    </TabContextProvider>
+  )
+}
+
+const PlaygroundComponent = ({ fullWidth, navigation, tab1, tab2, tab3 }: PlaygroundArgs) => {
+  const [value, setValue] = useState(0)
+  return <TabsDemo value={value} onChange={setValue} fullWidth={fullWidth} navigation={navigation} labels={[tab1, tab2, tab3]} />
 }
 
 export default {
@@ -19,147 +127,220 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/8mVm6LTbp2Z0RaWWjTZoft/%F0%9F%90%9DHIVE?node-id=880%3A4409',
+      url: 'https://www.figma.com/design/uGTDLFJEVy4dCNIhlmTPRw/%F0%9F%90%9D-HIVE-3.0?node-id=88-790',
+    },
+    docs: {
+      canvas: { sourceState: 'hidden' },
+    },
+    controls: {
+      exclude: ['ariaLabel', 'children', 'className'],
+    },
+  },
+  argTypes: {
+    fullWidth: {
+      control: 'boolean',
+      table: { category: 'Layout' },
+      description: 'Stretch tabs to fill the row width equally.',
+    },
+    navigation: {
+      control: 'boolean',
+      table: { category: 'Behavior' },
+      description: 'Render tabs as links (`component="a"`) instead of buttons.',
+    },
+    tab1: {
+      control: 'text',
+      table: { category: 'Content' },
+    },
+    tab2: {
+      control: 'text',
+      table: { category: 'Content' },
+    },
+    tab3: {
+      control: 'text',
+      table: { category: 'Content' },
     },
   },
   args: {
-    fullWidth: false,
+    fullWidth: true,
     navigation: false,
+    tab1: 'Tab 1',
+    tab2: 'Tab 2',
+    tab3: 'Tab 3',
   },
-} as Meta<Args>
+} as Meta<PlaygroundArgs>
 
-const Template: StoryFn<Args> = (args) => {
-  const tabProps: AnchorTabProps | ButtonTabProps = args.navigation
-    ? {
-        component: 'a',
-        href: '#',
-      }
-    : {}
-
-  return (
-    <TabContextProvider fullWidth={args.fullWidth}>
-      <TabList ariaLabel="Tabs Story">
-        <Tab ariaLabel="Tab 1" value={0} {...tabProps}>
-          Tab 1
-        </Tab>
-        <Tab ariaLabel="Tab 2" value={1} {...tabProps}>
-          Tab 2
-        </Tab>
-        <Tab ariaLabel="Tab 3" value={2} {...tabProps}>
-          Tab 3
-        </Tab>
-      </TabList>
-      <TabPanel value={0}>
-        <p>Panel 1</p>
-      </TabPanel>
-      <TabPanel value={1}>
-        <p>Panel 2</p>
-      </TabPanel>
-      <TabPanel value={2}>
-        <p>Panel 3</p>
-      </TabPanel>
-    </TabContextProvider>
-  )
+export const Playground: Story = {
+  render: (args) => <PlaygroundComponent {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tweak any prop in the Controls panel on the right. Rename tabs via **tab1**, **tab2**, **tab3**. Toggle **fullWidth** to stretch the list and **navigation** to render anchor tabs.',
+      },
+    },
+  },
 }
 
-export const Default = Template.bind({})
+export const Basic = () => (
+  <div className={s.section}>
+    <Caption>
+      Tabs organize related content within one surface. Use concise labels and keep the count low enough that users can scan options
+      quickly.
+    </Caption>
+    <TabsDemo fullWidth={false} labels={['Tab 1', 'Tab 2', 'Tab 3']} />
+  </div>
+)
+Basic.tags = ['!dev']
 
-export const FullWidth = Template.bind({})
-FullWidth.args = {
-  fullWidth: true,
-}
+export const FullWidth = () => (
+  <div className={s.section}>
+    <Caption>
+      Use <strong>fullWidth</strong> when tabs should span the entire row. This matches the selected Hive 4.0 design for container-level tab
+      navigation.
+    </Caption>
+    <TabsDemo fullWidth labels={['Tab 1', 'Tab 2', 'Tab 3']} />
+  </div>
+)
+FullWidth.tags = ['!dev']
 
-export const Navigation = Template.bind({})
-Navigation.args = {
-  navigation: true,
-}
+export const Navigation = () => (
+  <div className={s.section}>
+    <Caption>
+      Render tabs as links when each tab maps to URL navigation. Use this for route-driven pages where users can deep-link directly to a
+      tab.
+    </Caption>
+    <TabsDemo fullWidth={false} navigation labels={['Overview', 'Metrics', 'Settings']} />
+  </div>
+)
+Navigation.tags = ['!dev']
 
 export const Controlled = () => {
-  const [value, setValue] = useState<number>(0)
-
+  const [value, setValue] = useState(0)
   return (
-    <>
-      <p>
-        You can have more control over the value state by using TabContextProviderControlled component and providing your own `value` and
-        `onChange` props.
+    <div className={s.section}>
+      <Caption>
+        Use <strong>TabContextProviderControlled</strong> when the active tab is controlled from outside (URL, persisted preferences, or
+        analytics state).
+      </Caption>
+      <p className={s.caption}>
+        Active tab index: <strong>{value}</strong>
       </p>
-      <p>Active Tab: {value + 1}</p>
-      <TabContextProviderControlled value={value} onChange={setValue}>
-        <TabList ariaLabel="Tabs Story">
-          <Tab ariaLabel="Tab 1" value={0}>
-            Tab 1
-          </Tab>
-          <Tab ariaLabel="Tab 2" value={1}>
-            Tab 2
-          </Tab>
-          <Tab ariaLabel="Tab 3" value={2}>
-            Tab 3
-          </Tab>
-        </TabList>
-        <TabPanel value={0}>
-          <p>Panel 1</p>
-        </TabPanel>
-        <TabPanel value={1}>
-          <p>Panel 2</p>
-        </TabPanel>
-        <TabPanel value={2}>
-          <p>Panel 3</p>
-        </TabPanel>
-      </TabContextProviderControlled>
-    </>
+      <TabsDemo fullWidth={false} value={value} onChange={setValue} labels={['Tab 1', 'Tab 2', 'Tab 3']} />
+    </div>
   )
 }
+Controlled.tags = ['!dev']
 
 export const WithIcons = () => (
-  <TabContextProvider>
-    <TabList ariaLabel="Tabs Story">
-      <Tab ariaLabel="Tab 1" value={0}>
-        <Icon icon={Info} ariaLabel="Info" />
-        Tab 1
-      </Tab>
-      <Tab ariaLabel="Tab 2" value={1}>
-        <Icon icon={PenTool} ariaLabel="PenTool" />
-        Tab 2
-      </Tab>
-      <Tab ariaLabel="Tab 3" value={2}>
-        <Icon icon={Settings} ariaLabel="Settings" />
-        Tab 3
-      </Tab>
-    </TabList>
-    <TabPanel value={0}>
-      <p>Panel 1</p>
-    </TabPanel>
-    <TabPanel value={1}>
-      <p>Panel 2</p>
-    </TabPanel>
-    <TabPanel value={2}>
-      <p>Panel 3</p>
-    </TabPanel>
-  </TabContextProvider>
+  <div className={s.section}>
+    <Caption>
+      Icons can improve recognition, but the text label must still carry the meaning. Keep icon usage consistent across all tabs.
+    </Caption>
+    <TabsDemo fullWidth={false} withIcons labels={['Info', 'Design', 'Settings']} />
+  </div>
 )
+WithIcons.tags = ['!dev']
 
 export const CustomLabel = () => (
-  <TabContextProvider>
-    <TabList ariaLabel="Tabs Story">
-      <Tab value={0} ariaLabel="Tab 1">
-        <b>Tab</b> <Info /> 1
-      </Tab>
-      <Tab value={1} ariaLabel="Tab 2">
-        <b>Tab</b> <PenTool /> 2
-      </Tab>
-      <Tab value={2} ariaLabel="Tab 3">
-        <b>Tab</b>
-        <Settings /> 3
-      </Tab>
-    </TabList>
-    <TabPanel value={0}>
-      <p>Panel 1</p>
-    </TabPanel>
-    <TabPanel value={1}>
-      <p>Panel 2</p>
-    </TabPanel>
-    <TabPanel value={2}>
-      <p>Panel 3</p>
-    </TabPanel>
-  </TabContextProvider>
+  <div className={s.section}>
+    <Caption>Rich labels are supported, but keep labels short and legible. Avoid heavy formatting that makes scanning harder.</Caption>
+    <TabsDemo fullWidth={false} customLabel labels={['Tab 1', 'Tab 2', 'Tab 3']} />
+  </div>
 )
+CustomLabel.tags = ['!dev']
+
+export const States = () => (
+  <div className={s.section}>
+    <Caption>
+      QA matrix for visual verification. Each row sets a different active tab so engineers can validate selected styling and panel
+      switching.
+    </Caption>
+    <div className={`${s.grid} ${s.gridSizes}`}>
+      <Cell label="Active: Tab 1">
+        <TabsDemo fullWidth={false} value={0} onChange={() => {}} labels={['Tab 1', 'Tab 2', 'Tab 3']} />
+      </Cell>
+      <Cell label="Active: Tab 2">
+        <TabsDemo fullWidth={false} value={1} onChange={() => {}} labels={['Tab 1', 'Tab 2', 'Tab 3']} />
+      </Cell>
+      <Cell label="Active: Tab 3">
+        <TabsDemo fullWidth={false} value={2} onChange={() => {}} labels={['Tab 1', 'Tab 2', 'Tab 3']} />
+      </Cell>
+    </div>
+  </div>
+)
+States.parameters = {
+  docs: {
+    description: {
+      story: 'Visual QA matrix. Not part of the public design spec - included so engineers can verify selected tab state quickly.',
+    },
+  },
+}
+States.tags = ['!dev']
+
+export const DoVsDont = () => (
+  <div className={s.doDont}>
+    <div className={s.doDontRow}>
+      <h3 className={s.doDontHeading}>Label Length</h3>
+      <div className={`${s.doDontCard} ${s.doDontGood}`}>
+        <div className={s.doDontMarker}>Do</div>
+        <div className={s.doDontDemo}>
+          <TabsDemo fullWidth={false} value={0} onChange={() => {}} labels={['Overview', 'Metrics', 'Settings']} />
+        </div>
+        <p className={s.doDontNote}>Use short, parallel labels that are easy to scan.</p>
+      </div>
+      <div className={`${s.doDontCard} ${s.doDontBad}`}>
+        <div className={s.doDontMarker}>Don&apos;t</div>
+        <div className={s.doDontDemo}>
+          <TabsDemo
+            fullWidth={false}
+            value={0}
+            onChange={() => {}}
+            labels={['Overview and summary details', 'Performance metrics and health', 'Settings and configuration']}
+          />
+        </div>
+        <p className={s.doDontNote}>Avoid sentence-length tab labels.</p>
+      </div>
+    </div>
+
+    <div className={s.doDontRow}>
+      <h3 className={s.doDontHeading}>Hierarchy</h3>
+      <div className={`${s.doDontCard} ${s.doDontGood}`}>
+        <div className={s.doDontMarker}>Do</div>
+        <div className={s.doDontDemo}>
+          <TabsDemo fullWidth={false} value={0} onChange={() => {}} labels={['General', 'Security', 'Notifications']} />
+        </div>
+        <p className={s.doDontNote}>Use one clear tab row per content section.</p>
+      </div>
+      <div className={`${s.doDontCard} ${s.doDontBad}`}>
+        <div className={s.doDontMarker}>Don&apos;t</div>
+        <div className={s.doDontDemo}>
+          <TabsDemo fullWidth={false} value={0} onChange={() => {}} labels={['General', 'Security', 'Notifications']} />
+          <TabsDemo fullWidth={false} value={0} onChange={() => {}} labels={['Billing', 'Access', 'Audit']} />
+        </div>
+        <p className={s.doDontNote}>Do not stack nested tab bars unless absolutely required.</p>
+      </div>
+    </div>
+  </div>
+)
+DoVsDont.tags = ['!dev']
+
+export const LegacyV3 = () => (
+  <div className={s.section}>
+    <Caption>
+      The v3 Tabs is preserved for gradual migration. Import from <strong>@hazelcast/ui/old</strong>. New code should use the Tabs above.
+    </Caption>
+    <div className={s.row}>
+      <LegacyTabContextProvider>
+        <LegacyTabList ariaLabel="Tabs demo">
+          <LegacyTab value={0}>General</LegacyTab>
+          <LegacyTab value={1}>Security</LegacyTab>
+          <LegacyTab value={2}>Notifications</LegacyTab>
+        </LegacyTabList>
+        <LegacyTabPanel value={0}>Content for General</LegacyTabPanel>
+        <LegacyTabPanel value={1}>Content for Security</LegacyTabPanel>
+        <LegacyTabPanel value={2}>Content for Notifications</LegacyTabPanel>
+      </LegacyTabContextProvider>
+    </div>
+  </div>
+)
+LegacyV3.tags = ['!dev']

--- a/docs/migration-v4.md
+++ b/docs/migration-v4.md
@@ -33,6 +33,7 @@ grep -r "@hazelcast/ui/old" src --include="*.tsx" --include="*.ts"
 | New      | `ButtonGroup` | Group of joined `Button`s sharing border-radius and shadow                                                                                                                                                                      | n/a             |
 | Updated  | `Toggle`      | HIVE 4.0 pill switch; SCSS → CSS; no ON/OFF label                                                                                                                                                                               | ✅              |
 | Updated  | `TextField`   | HIVE 4.0 rebrand; 36px height; 8px radius; `--hive-*` tokens; SCSS → CSS                                                                                                                                                        | ✅              |
+| Updated  | `Tabs`        | HIVE 4.0 visual redesign; pill-segmented shape with gray background; no API changes; SCSS → CSS                                                                                                                                 | ✅              |
 
 ---
 
@@ -337,6 +338,74 @@ import { TextField } from '@hazelcast/ui'
 ```
 
 `NumberField`, `PasswordField`, `AutocompleteField`, `TimeField`, and `SelectField` all consume `TextField`-style classes; their visuals follow automatically.
+
+---
+
+### `Tabs`
+
+Visual redesign to the HIVE 4.0 pill-segmented tabs: `36px` container with `3.5px` padding, `14px` border-radius, neutral gray background (`#eaebec`), and white selected state. The typography and interaction model remain unchanged. Styles have been migrated from SCSS to CSS modules.
+
+The public prop contract is unchanged; only visuals and internal styling have changed.
+
+**Old import (temporary fallback):**
+
+```ts
+import { Tab, TabList, TabPanel, TabContext, TabContextProvider, TabContextProviderControlled } from '@hazelcast/ui/old'
+```
+
+**Prop changes:**
+
+| Prop  | v3              | v4                                 |
+| ----- | --------------- | ---------------------------------- |
+| _all_ | same public API | same — visual-only breaking change |
+
+**Visual / DOM changes:**
+
+| Aspect            | v3                                            | v4                                                            |
+| ----------------- | --------------------------------------------- | ------------------------------------------------------------- |
+| Container height  | `40px` (`c.$grid * 10`)                       | `36px`                                                        |
+| Container radius  | none (flex row)                               | `14px` (pill shape)                                           |
+| Container bg      | transparent                                   | `#eaebec` (neutral gray)                                      |
+| Tab height        | `40px` (`c.$grid * 10`)                       | `29px`                                                        |
+| Tab padding       | `1px 20px` (`c.$grid × c.$grid * 5`)          | `5px 9px`                                                     |
+| Tab radius        | none (underline style)                        | `14px` (pill shape)                                           |
+| Selected state    | blue underline (`borderBottom` + `boxShadow`) | white background (`#fff`)                                     |
+| Unselected border | `1px solid` neutral light bottom              | removed (transparent)                                         |
+| Stylesheet        | `Tab.module.scss` + `TabList.module.scss`     | `Tab.module.scss` + `TabList.module.scss` using CSS variables |
+
+**Before:**
+
+```tsx
+import { TabContextProvider, TabList, Tab, TabPanel } from '@hazelcast/ui'
+;<TabContextProvider>
+  <TabList ariaLabel="Tabs demo">
+    <Tab value={0}>General</Tab>
+    <Tab value={1}>Security</Tab>
+    <Tab value={2}>Notifications</Tab>
+  </TabList>
+  <TabPanel value={0}>Content for General</TabPanel>
+  <TabPanel value={1}>Content for Security</TabPanel>
+  <TabPanel value={2}>Content for Notifications</TabPanel>
+</TabContextProvider>
+// Renders as a row of underlined tabs with blue underline for selected.
+```
+
+**After:**
+
+```tsx
+import { TabContextProvider, TabList, Tab, TabPanel } from '@hazelcast/ui'
+;<TabContextProvider>
+  <TabList ariaLabel="Tabs demo">
+    <Tab value={0}>General</Tab>
+    <Tab value={1}>Security</Tab>
+    <Tab value={2}>Notifications</Tab>
+  </TabList>
+  <TabPanel value={0}>Content for General</TabPanel>
+  <TabPanel value={1}>Content for Security</TabPanel>
+  <TabPanel value={2}>Content for Notifications</TabPanel>
+</TabContextProvider>
+// Renders as a pill-segmented row with white selected state.
+```
 
 ---
 

--- a/src/components/Tabs/Tab.module.css
+++ b/src/components/Tabs/Tab.module.css
@@ -23,7 +23,6 @@
   font-size: var(--hive-font-size-body-small);
   font-weight: var(--hive-font-weight-text-medium);
   line-height: 1;
-  letter-spacing: -0.0094rem;
 }
 
 .tab > * {

--- a/src/components/Tabs/Tab.module.css
+++ b/src/components/Tabs/Tab.module.css
@@ -11,7 +11,7 @@
   min-width: 0;
   padding: calc(var(--hive-grid) * 1.25) calc(var(--hive-grid) * 2.25);
   border: var(--hive-border-width) solid transparent;
-  border-radius: calc(var(--hive-grid) * 3.5);
+  border-radius: 9999px;
   color: var(--hive-color-text-v4);
   background-color: transparent;
   cursor: pointer;

--- a/src/components/Tabs/Tab.module.css
+++ b/src/components/Tabs/Tab.module.css
@@ -11,7 +11,7 @@
   min-width: 0;
   padding: calc(var(--hive-grid) * 1.25) calc(var(--hive-grid) * 2.25);
   border: var(--hive-border-width) solid transparent;
-  border-radius: 9999px;
+  border-radius: var(--hive-border-radius-pill);
   color: var(--hive-color-text-v4);
   background-color: transparent;
   cursor: pointer;

--- a/src/components/Tabs/Tab.module.css
+++ b/src/components/Tabs/Tab.module.css
@@ -31,8 +31,6 @@
 }
 
 .tab.selected {
-  color: var(--hive-color-text-v4);
-  border-radius: calc(var(--hive-grid) * 3.5);
   background: var(--hive-color-neutral-white-v4);
 }
 

--- a/src/components/Tabs/Tab.module.css
+++ b/src/components/Tabs/Tab.module.css
@@ -1,0 +1,52 @@
+.tab {
+  display: inline-flex;
+  flex: 1 1 0;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: calc(var(--hive-grid) * 1.5);
+  position: relative;
+  box-sizing: border-box;
+  height: calc(var(--hive-grid) * 7.25);
+  min-width: 0;
+  padding: calc(var(--hive-grid) * 1.25) calc(var(--hive-grid) * 2.25);
+  border: var(--hive-border-width) solid transparent;
+  border-radius: calc(var(--hive-grid) * 3.5);
+  color: var(--hive-color-text-v4);
+  background-color: transparent;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+
+  font-family: var(--hive-font-family-text);
+  font-size: var(--hive-font-size-body-small);
+  font-weight: var(--hive-font-weight-text-medium);
+  line-height: 1;
+  letter-spacing: -0.0094rem;
+}
+
+.tab > * {
+  display: inline-flex;
+  align-items: center;
+}
+
+.tab.selected {
+  color: var(--hive-color-text-v4);
+  border-radius: calc(var(--hive-grid) * 3.5);
+  background: var(--hive-color-neutral-white-v4);
+}
+
+.tab.fullWidth {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.tab:hover {
+  color: var(--hive-color-text-v4);
+}
+
+.tab:focus-visible {
+  outline: var(--hive-outline-width) solid var(--hive-color-primary-v4);
+  outline-offset: 2px;
+}

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -4,7 +4,7 @@ import cn from 'classnames'
 import { useTabContext, getTabId, getPanelId } from './TabContext'
 import { keyIsOneOf } from '../../utils/keyboard'
 
-import styles from './Tab.module.scss'
+import styles from './Tab.module.css'
 
 export type AnchorTabProps = {
   component: 'a'

--- a/src/components/Tabs/TabList.module.css
+++ b/src/components/Tabs/TabList.module.css
@@ -1,0 +1,12 @@
+.tabList {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  width: 100%;
+  height: calc(var(--hive-grid) * 9);
+  padding: calc(var(--hive-grid) * 0.875) calc(var(--hive-grid) * 0.75);
+  border-radius: calc(var(--hive-grid) * 3.5);
+  background: var(--hive-color-secondary-v4);
+  box-sizing: border-box;
+  overflow: hidden;
+}

--- a/src/components/Tabs/TabList.module.scss
+++ b/src/components/Tabs/TabList.module.scss
@@ -1,3 +1,0 @@
-.tabList {
-  display: flex;
-}

--- a/src/components/Tabs/TabList.tsx
+++ b/src/components/Tabs/TabList.tsx
@@ -1,7 +1,7 @@
 import React, { FC, ReactNode, KeyboardEvent, useRef, useCallback } from 'react'
 import cn from 'classnames'
 
-import styles from './TabList.module.scss'
+import styles from './TabList.module.css'
 
 export type TabListProps = {
   ariaLabel: string

--- a/src/components/Tabs/TabPanel.module.css
+++ b/src/components/Tabs/TabPanel.module.css
@@ -1,0 +1,7 @@
+.tabPanel {
+  visibility: visible;
+}
+
+.tabPanel.hidden {
+  visibility: hidden;
+}

--- a/src/components/Tabs/TabPanel.module.scss
+++ b/src/components/Tabs/TabPanel.module.scss
@@ -1,7 +1,0 @@
-.tabPanel {
-  visibility: visible;
-
-  .hidden {
-    visibility: hidden;
-  }
-}

--- a/src/components/Tabs/TabPanel.tsx
+++ b/src/components/Tabs/TabPanel.tsx
@@ -4,7 +4,7 @@ import cn from 'classnames'
 import { DataTestProp } from '../../helpers/types'
 import { useTabContext, getPanelId, getTabId } from './TabContext'
 
-import styles from './TabPanel.module.scss'
+import styles from './TabPanel.module.css'
 
 export type TabPanelProps = {
   value: number

--- a/src/components/Toggle.module.css
+++ b/src/components/Toggle.module.css
@@ -46,7 +46,7 @@
   display: inline-block;
   width: var(--toggle-track-width);
   height: var(--toggle-track-height);
-  border-radius: 9999px;
+  border-radius: var(--hive-border-radius-pill);
   background: var(--toggle-track-bg);
   border: var(--hive-border-width) solid transparent;
   box-sizing: border-box;
@@ -61,7 +61,7 @@
   width: var(--toggle-thumb-size);
   height: var(--toggle-thumb-size);
   background: var(--toggle-thumb-bg);
-  border-radius: 9999px;
+  border-radius: var(--hive-border-radius-pill);
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.1),
     0 1px 2px rgba(0, 0, 0, 0.1);

--- a/src/old/Tabs.tsx
+++ b/src/old/Tabs.tsx
@@ -1,0 +1,219 @@
+import React, { createContext, useContext, FC, useMemo, useState, ReactNode, useCallback, useRef, MouseEvent, KeyboardEvent } from 'react'
+import cn from 'classnames'
+import { useUID } from 'react-uid'
+
+import { DataTestProp } from '../helpers/types'
+import { keyIsOneOf } from '../utils/keyboard'
+
+import styles from './TabsLegacy.module.scss'
+
+// ---------- TabContext ----------
+
+export type TabContextValue = {
+  onChange: (value: number) => void
+  value: number
+  idPrefix: string
+  fullWidth?: boolean
+}
+
+export const tabContextDefaultValue: TabContextValue = {
+  onChange: () => {
+    // default function - do nothing ¯\_(ツ)_/¯
+  },
+  value: 0,
+  idPrefix: '',
+  fullWidth: false,
+}
+
+export const TabContext = createContext<TabContextValue>(tabContextDefaultValue)
+
+export const useTabContext = () => useContext(TabContext)
+
+export type TabContextProviderProps = Pick<TabContextValue, 'fullWidth'> & { children: ReactNode }
+
+export const TabContextProvider: FC<TabContextProviderProps> = ({ fullWidth, children }) => {
+  const [value, setValue] = useState<number>(0)
+
+  return (
+    <TabContextProviderControlled value={value} onChange={setValue} fullWidth={fullWidth}>
+      {children}
+    </TabContextProviderControlled>
+  )
+}
+
+export type TabContextProviderControlledProps = Omit<TabContextValue, 'idPrefix'> & { children: ReactNode }
+
+export const TabContextProviderControlled: FC<TabContextProviderControlledProps> = ({ onChange, value, fullWidth, children }) => {
+  const id = useUID()
+  const contextValue: TabContextValue = useMemo(
+    () => ({
+      onChange,
+      value,
+      idPrefix: id,
+      fullWidth,
+    }),
+    [onChange, value, id, fullWidth],
+  )
+
+  return <TabContext.Provider value={contextValue}>{children}</TabContext.Provider>
+}
+
+export const getTabId = (prefix: string, value: string) => `${prefix}-tab-${value}`
+export const getPanelId = (prefix: string, value: string) => `${prefix}-panel-${value}`
+
+// ---------- TabList ----------
+
+export type TabListProps = {
+  ariaLabel: string
+  className?: string
+  children: ReactNode
+}
+
+export const TabList: FC<TabListProps> = ({ ariaLabel, className, children }) => {
+  const tabListRef = useRef<HTMLDivElement>(null)
+
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLButtonElement
+    const role = target.getAttribute('role')
+    if (role !== 'tab') {
+      console.warn('Children of TabList component do not have [role="tab"]. Keyboard navigation will not work as expected.')
+      return
+    }
+
+    let newFocusTarget: HTMLButtonElement | null = null
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        newFocusTarget =
+          (target.previousElementSibling as HTMLButtonElement) ?? (tabListRef.current?.lastChild as HTMLButtonElement) ?? null
+        break
+      case 'ArrowRight':
+        newFocusTarget = (target.nextElementSibling as HTMLButtonElement) ?? (tabListRef.current?.firstChild as HTMLButtonElement) ?? null
+        break
+      case 'Home':
+        newFocusTarget = (tabListRef.current?.firstChild as HTMLButtonElement) ?? null
+        break
+      case 'End':
+        newFocusTarget = (tabListRef.current?.lastChild as HTMLButtonElement) ?? null
+        break
+      default:
+        break
+    }
+
+    if (newFocusTarget !== null) {
+      newFocusTarget.focus()
+      event.preventDefault()
+    }
+  }, [])
+
+  return (
+    <div
+      data-test="tab-list"
+      className={cn(styles.tabList, className)}
+      aria-label={ariaLabel}
+      role="tablist"
+      ref={tabListRef}
+      onKeyDown={handleKeyDown}
+    >
+      {children}
+    </div>
+  )
+}
+
+// ---------- Tab ----------
+
+export type AnchorTabProps = {
+  component: 'a'
+  href: string
+}
+
+export type ButtonTabProps = {
+  component?: 'button'
+  href?: never
+}
+
+type TabTypeProps = AnchorTabProps | ButtonTabProps
+
+type TabLabelProps = {
+  children: ReactNode
+  ariaLabel?: string
+}
+
+export type TabCommonProps = {
+  value: number
+  onClick?: (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement> | KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>) => void
+  className?: string
+}
+export type TabProps<T = TabTypeProps> = TabCommonProps & T & TabLabelProps
+
+export const Tab: FC<TabProps> = ({ component: Component = 'button', value, href, onClick, children, ariaLabel, className }) => {
+  const { onChange, value: activeValue, idPrefix, fullWidth } = useTabContext()
+  const selected = value === activeValue
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement> | KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>) => {
+      if (selected) {
+        return
+      }
+
+      if (onClick) {
+        onClick(event)
+      }
+
+      onChange(value)
+    },
+    [value, selected, onChange, onClick],
+  )
+
+  const onKeyPress = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>) => {
+      event.preventDefault()
+
+      if (keyIsOneOf(event, 'Enter', 'Space')) {
+        handleClick(event)
+      }
+    },
+    [handleClick],
+  )
+
+  return (
+    <Component
+      className={cn(styles.tab, { [styles.selected]: selected, [styles.fullWidth]: fullWidth }, className)}
+      role="tab"
+      id={getTabId(idPrefix, value.toString())}
+      aria-controls={getPanelId(idPrefix, value.toString())}
+      aria-selected={selected}
+      tabIndex={selected ? 0 : -1}
+      onKeyPress={onKeyPress}
+      onClick={handleClick}
+      {...(Component === 'a' && !selected && { href })}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </Component>
+  )
+}
+
+// ---------- TabPanel ----------
+
+export type TabPanelProps = {
+  value: number
+  children: ReactNode
+} & DataTestProp
+
+export const TabPanel: FC<TabPanelProps> = ({ value, children, 'data-test': dataTest }) => {
+  const { idPrefix, value: selectedValue } = useTabContext()
+  const selected = value === selectedValue
+
+  return (
+    <div
+      className={cn(styles.tabPanel, { [styles.hidden]: !selected })}
+      role="tabpanel"
+      data-test={dataTest}
+      id={getPanelId(idPrefix, value.toString())}
+      aria-labelledby={getTabId(idPrefix, value.toString())}
+    >
+      {selected ? children : null}
+    </div>
+  )
+}

--- a/src/old/TabsLegacy.module.scss
+++ b/src/old/TabsLegacy.module.scss
@@ -1,5 +1,9 @@
-@use '../../../styles/constants' as c;
-@use '../../../styles/helpers' as h;
+@use '../../styles/constants' as c;
+@use '../../styles/helpers' as h;
+
+.tabList {
+  display: flex;
+}
 
 .tab {
   display: flex;
@@ -17,8 +21,6 @@
   color: c.$colorText;
   background-color: transparent;
   cursor: pointer;
-
-  // for <a> element
   text-decoration: none;
 
   @include c.typographyH3;
@@ -46,13 +48,19 @@
   }
 
   &:focus-visible {
-    // Do not remove outline for high-contrast modes
-    // https://stackoverflow.com/a/52616313
     outline: c.$outlineWidth solid transparent;
     color: c.$colorPrimary;
     border-radius: c.$borderRadius;
     border-color: transparent;
 
     @include h.outlineSimple;
+  }
+}
+
+.tabPanel {
+  visibility: visible;
+
+  .hidden {
+    visibility: hidden;
   }
 }

--- a/src/old/index.ts
+++ b/src/old/index.ts
@@ -25,3 +25,15 @@ export { TextField } from './TextField'
 export type { TextFieldProps, TextFieldExtraProps, TextFieldSize, TextFieldVariant, TextFieldTypes } from './TextField'
 export { TextFieldFormik } from './TextFieldFormik'
 export type { TextFieldFormikProps } from './TextFieldFormik'
+export { TabContext, TabContextProvider, TabContextProviderControlled, useTabContext, TabList, Tab, TabPanel } from './Tabs'
+export type {
+  TabContextValue,
+  TabContextProviderProps,
+  TabContextProviderControlledProps,
+  TabListProps,
+  TabProps,
+  TabCommonProps,
+  AnchorTabProps,
+  ButtonTabProps,
+  TabPanelProps,
+} from './Tabs'

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -88,6 +88,7 @@
   --hive-border-radius-badge: 37px;
   --hive-border-radius-time-field: 3px;
   --hive-border-radius-notification: 3px;
+  --hive-border-radius-pill: 9999px;
 
   /* ─── Icons ───────────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary

Restyles `Tabs` to the HIVE 4.0 pill-segmented design and migrates SCSS → CSS modules with design tokens. Public API unchanged — visual-only breaking change with `/old` fallback.

## Changes

- **Component**: `Tab`, `TabList`, `TabPanel` migrated from SCSS to CSS modules using `--hive-*` design tokens (no new tokens added)
- **Visual**: 36px pill container, 29px inner tabs, gray bg (`--hive-color-secondary-v4`), white selected state
- **Legacy**: v3 implementation moved to `src/old/Tabs.tsx` + `TabsLegacy.module.scss`, exported via `@hazelcast/ui/old`
- **Storybook**: New `Tabs.mdx` (Overview / Guidelines / Accessibility tabs), Playground + Basic / FullWidth / Navigation / Controlled / WithIcons / CustomLabel / States / DoVsDont / LegacyV3 stories
- **Migration guide**: Added `### Tabs` section with v3 → v4 visual diff and code examples

## Validation

- `npm test` → 458 tests pass
- `npm run compile` → build passes
- `npx eslint` → clean

## Related

HZC-7903