### PR TITLE
HZC-7919 Add fullWidth prop to Button

### DIFF
--- a/__stories__/Button.stories.module.scss
+++ b/__stories__/Button.stories.module.scss
@@ -112,7 +112,14 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  max-width: 480px;
+}
+
+.playgroundContainer {
+  width: 480px;
+  max-width: 100%;
+  padding: 16px;
+  border: 1px dashed var(--hive-color-border-v4, #d0d4d9);
+  border-radius: 8px;
 }
 
 .doDont {

--- a/__stories__/Button.stories.tsx
+++ b/__stories__/Button.stories.tsx
@@ -173,13 +173,17 @@ export const Playground: Story = {
     iconLeftAriaLabel: 'leading',
     iconRightAriaLabel: 'trailing',
   },
-  render: ({ tooltip, ...args }) => <Button {...args} tooltip={tooltip ? tooltip : undefined} />,
+  render: ({ tooltip, ...args }) => (
+    <div className={s.playgroundContainer}>
+      <Button {...args} tooltip={tooltip ? tooltip : undefined} />
+    </div>
+  ),
   parameters: {
     layout: 'centered',
     docs: {
       description: {
         story:
-          'Tweak any prop in the Controls panel on the right. Pick icons from the **left icon** and **right icon** dropdowns. Type into **tooltip** to enable a hover tooltip; clear it to disable.',
+          'Tweak any prop in the Controls panel on the right. Pick icons from the **left icon** and **right icon** dropdowns. Type into **tooltip** to enable a hover tooltip; clear it to disable. The dashed box shows the parent container — toggle **fullWidth** to see the button stretch to fill it.',
       },
     },
   },

--- a/__stories__/Button.stories.tsx
+++ b/__stories__/Button.stories.tsx
@@ -342,17 +342,17 @@ Loading.tags = ['!dev']
 export const FullWidth = () => (
   <div className={s.section}>
     <Caption>
-      Buttons stretch to fill their container when given a block-level class. Useful in modals, narrow forms, and mobile layouts. Long
+      Pass <strong>fullWidth</strong> to stretch a button to fill its container. Useful in modals, narrow forms, and mobile layouts. Long
       labels truncate with an ellipsis.
     </Caption>
     <div className={s.fullWidthDemo}>
-      <Button className={s.block} iconLeft={Plus} iconLeftAriaLabel="Add">
+      <Button fullWidth iconLeft={Plus} iconLeftAriaLabel="Add">
         Create new project
       </Button>
-      <Button className={s.block} variant="outlined" color="secondary">
+      <Button fullWidth variant="outlined" color="secondary">
         Cancel
       </Button>
-      <Button className={s.block}>Looooooooooooooooooooooooooooooooong label that gets truncated</Button>
+      <Button fullWidth>Looooooooooooooooooooooooooooooooong label that gets truncated</Button>
     </div>
   </div>
 )

--- a/__tests__/components/Button.test.tsx
+++ b/__tests__/components/Button.test.tsx
@@ -53,6 +53,18 @@ describe('Button', () => {
     expect(screen.getByTestId('button')).toHaveClass(className)
   })
 
+  it('Renders Button with fullWidth class when fullWidth prop is true', async () => {
+    await renderAndCheckA11Y(<Button fullWidth>{label}</Button>)
+
+    expect(screen.getByTestId('button')).toHaveClass(styles.fullWidth)
+  })
+
+  it('Does not apply fullWidth class by default', async () => {
+    await renderAndCheckA11Y(<Button>{label}</Button>)
+
+    expect(screen.getByTestId('button')).not.toHaveClass(styles.fullWidth)
+  })
+
   it('Renders Button with default variant contained, color primary, and size regular', async () => {
     await renderAndCheckA11Y(<Button>{label}</Button>)
 

--- a/src/components/Button.module.css
+++ b/src/components/Button.module.css
@@ -47,6 +47,12 @@
   --button-padding-x: 16px;
 }
 
+.fullWidth {
+  display: flex;
+  width: 100%;
+  max-width: 100%;
+}
+
 .button:hover,
 .button.hover {
   background: var(--button-bg-hover);

--- a/src/components/Button.module.css
+++ b/src/components/Button.module.css
@@ -47,7 +47,7 @@
   --button-padding-x: 16px;
 }
 
-.fullWidth {
+.fullWidth.fullWidth {
   display: flex;
   width: 100%;
   max-width: 100%;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -68,6 +68,7 @@ export type ButtonCommonProps = {
   tooltip?: string
   active?: boolean
   truncate?: boolean
+  fullWidth?: boolean
 } & (ButtonDisabledProps | ButtonNotDisabledProps) &
   Pick<HTMLAttributes<HTMLAnchorElement | HTMLButtonElement>, 'className' | 'onClick' | 'tabIndex' | 'style'>
 
@@ -145,6 +146,7 @@ export const Button = forwardRef<HTMLElement, ButtonProps>(
       tooltip,
       active,
       truncate = true,
+      fullWidth,
       ...rest
     },
     ref,
@@ -171,6 +173,7 @@ export const Button = forwardRef<HTMLElement, ButtonProps>(
             {
               [styles.active]: active,
               [styles.inset]: outline === 'inset',
+              [styles.fullWidth]: fullWidth,
             },
             className,
           )}


### PR DESCRIPTION
## Summary

Adds a new `fullWidth` boolean prop to `Button` so it can stretch to fill its container, overriding the default `inline-flex` layout and the `--hive-button-max-width` (370px) cap.

## Changes

- `src/components/Button.tsx` — new `fullWidth?: boolean` prop on `ButtonCommonProps`; applies `styles.fullWidth` conditionally.
- `src/components/Button.module.css` — `.fullWidth { display: flex; width: 100%; max-width: 100%; }`.
- `__stories__/Button.stories.tsx` — `FullWidth` story now uses the prop instead of a local block class.
- `__tests__/components/Button.test.tsx` — coverage for both \`fullWidth\` true and default.

## Tests

- \`npm test -- --testPathPattern=Button\` ✅ (40 tests)
- \`npm run lint\` ✅

## Jira

HZC-7919