### PR TITLE
hzc-8000: redesign the SelectField component HIVE v4

### DIFF
--- a/__stories__/AutocompleteField.stories.tsx
+++ b/__stories__/AutocompleteField.stories.tsx
@@ -52,11 +52,6 @@ export default {
     placeholder: { control: 'text', table: { category: 'Content' } },
     helperText: { control: 'text', table: { category: 'Content' } },
     error: { control: 'text', table: { category: 'State' } },
-    size: {
-      control: 'inline-radio',
-      options: ['small', 'medium'],
-      table: { category: 'Layout', defaultValue: { summary: 'medium' } },
-    },
     disabled: { control: 'boolean', table: { category: 'State' } },
     isClearable: { control: 'boolean', table: { category: 'Behavior' } },
     openMenuOnClick: { control: 'boolean', table: { category: 'Behavior' } },
@@ -123,18 +118,14 @@ Basic.tags = ['!dev']
 
 export const Sizes = () => {
   const [a, setA] = useState<string | null>(options[1].value)
-  const [b, setB] = useState<string | null>(options[1].value)
   return (
     <div className={s.section}>
       <Caption>
-        Two sizes: <strong>small</strong> for dense tables, <strong>medium</strong> (default) for most forms.
+        AutocompleteField renders at a single <strong>regular</strong> size — the compact field height used across forms.
       </Caption>
       <div className={`${s.grid} ${s.gridSizes}`} style={{ gridTemplateColumns: 'repeat(2, 320px)' }}>
-        <Cell label="Small">
-          <AutocompleteField name="size-small" size="small" label="Character" options={options} value={a} onChange={setA} />
-        </Cell>
-        <Cell label="Medium">
-          <AutocompleteField name="size-medium" label="Character" options={options} value={b} onChange={setB} />
+        <Cell label="Regular">
+          <AutocompleteField name="size-regular" label="Character" options={options} value={a} onChange={setA} />
         </Cell>
       </div>
     </div>

--- a/__stories__/MultiSelectField.mdx
+++ b/__stories__/MultiSelectField.mdx
@@ -27,7 +27,7 @@ explicit checkboxes that stay open while picking, use `CheckableSelectField`.
 
         <h2>Sizes</h2>
 
-        <p>Two sizes — <code>small</code> for dense tables and toolbars, <code>medium</code> (default) for most forms.</p>
+        <p>MultiSelectField renders at a single <code>regular</code> size — the compact field height used across forms.</p>
 
         <Canvas of={MultiSelectFieldStories.Sizes} />
 

--- a/__stories__/MultiSelectField.mdx
+++ b/__stories__/MultiSelectField.mdx
@@ -97,6 +97,10 @@ explicit checkboxes that stay open while picking, use `CheckableSelectField`.
         <h2>Chips</h2>
 
         <p>Each selected value renders as a chip with a remove button. Chips wrap to additional lines when they exceed the control width — design for that.</p>
+
+        <h2>Do &amp; Don&rsquo;t</h2>
+
+        <Canvas of={MultiSelectFieldStories.DoVsDont} />
       </>
     ),
   },

--- a/__stories__/MultiSelectField.stories.tsx
+++ b/__stories__/MultiSelectField.stories.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useState } from 'react'
 import { Meta, StoryObj } from '@storybook/react'
 import { Form, Formik } from 'formik'
+import { Check, X } from 'react-feather'
 
 import { logger } from '../src'
 import { MultiSelectField, MultiSelectProps } from '../src/components/Select/MultiSelectField'
@@ -44,7 +45,7 @@ export default {
     },
     docs: { canvas: { sourceState: 'hidden' } },
     controls: {
-      exclude: ['name', 'value', 'className', 'menuPortalTarget', 'onBlur', 'onChange', 'noOptionsMessage', 'options', 'data-test'],
+      include: ['label', 'placeholder', 'helperText', 'error', 'disabled', 'isCreatable', 'isSearchable', 'menuIsOpen'],
     },
   },
   argTypes: {
@@ -54,6 +55,8 @@ export default {
     error: { control: 'text', table: { category: 'State' } },
     disabled: { control: 'boolean', table: { category: 'State' } },
     isCreatable: { control: 'boolean', table: { category: 'Behavior' } },
+    isSearchable: { control: 'boolean', table: { category: 'Behavior' } },
+    menuIsOpen: { control: 'boolean', table: { category: 'State' } },
   },
   args: {
     name: 'characters',
@@ -297,3 +300,159 @@ export const LegacyV3 = () => {
   )
 }
 LegacyV3.tags = ['!dev']
+
+type DoDontPair = {
+  heading: string
+  good: { note: string; demo: ReactNode }
+  bad: { note: string; demo: ReactNode }
+}
+
+const Demo = ({ children }: { children: ReactNode }) => <div style={{ width: '100%' }}>{children}</div>
+
+const longOptions: SelectFieldOption<string>[] = [
+  { value: 'a', label: LONG_MULTIPLE_WORD_TEXT },
+  { value: 'b', label: LONG_ONE_WORD_TEXT },
+  ...options,
+]
+
+const DO_DONT_PAIRS: DoDontPair[] = [
+  {
+    heading: 'Use chips for a manageable number of selections',
+    good: {
+      note: 'A handful of chips reads cleanly in one or two rows and stays scannable.',
+      demo: (
+        <Demo>
+          <MultiSelectField
+            name="dd-count-good"
+            label="Characters"
+            options={options}
+            value={[options[1].value, options[2].value]}
+            onChange={() => {}}
+          />
+        </Demo>
+      ),
+    },
+    bad: {
+      note: 'When users routinely pick many values the chips pile up — reach for CheckableSelectField instead.',
+      demo: (
+        <Demo>
+          <MultiSelectField
+            name="dd-count-bad"
+            label="Characters"
+            options={options}
+            value={options.map((o) => o.value)}
+            onChange={() => {}}
+          />
+        </Demo>
+      ),
+    },
+  },
+  {
+    heading: 'Keep option labels short so chips stay compact',
+    good: {
+      note: 'Short labels make small chips, so several fit on one row.',
+      demo: (
+        <Demo>
+          <MultiSelectField
+            name="dd-label-good"
+            label="Characters"
+            options={options}
+            value={[options[0].value, options[3].value]}
+            onChange={() => {}}
+          />
+        </Demo>
+      ),
+    },
+    bad: {
+      note: 'Long labels become oversized chips that wrap and truncate — trim them before they reach the control.',
+      demo: (
+        <Demo>
+          <MultiSelectField name="dd-label-bad" label="Characters" options={longOptions} value={['a', 'b']} onChange={() => {}} />
+        </Demo>
+      ),
+    },
+  },
+  {
+    heading: 'Reach for MultiSelectField only when many values apply',
+    good: {
+      note: 'Use it when zero, one, or many values are all valid answers.',
+      demo: (
+        <Demo>
+          <MultiSelectField
+            name="dd-fit-good"
+            label="Characters"
+            options={options}
+            value={[options[1].value, options[4].value]}
+            onChange={() => {}}
+          />
+        </Demo>
+      ),
+    },
+    bad: {
+      note: 'If exactly one value is ever correct, a SelectField is clearer and prevents invalid multi-selections.',
+      demo: (
+        <Demo>
+          <MultiSelectField name="dd-fit-bad" label="Primary character" options={options} value={[options[1].value]} onChange={() => {}} />
+        </Demo>
+      ),
+    },
+  },
+  {
+    heading: 'Surface validation inline \u2014 don\u2019t disable the field',
+    good: {
+      note: 'Use error to explain what\u2019s missing. The control turns invalid and announces the message.',
+      demo: (
+        <Demo>
+          <MultiSelectField
+            name="dd-error-good"
+            label="Characters"
+            options={options}
+            value={[]}
+            error="Pick at least one"
+            onChange={() => {}}
+          />
+        </Demo>
+      ),
+    },
+    bad: {
+      note: 'Don\u2019t disable a required field to force a choice \u2014 disabled controls aren\u2019t focusable and give no guidance.',
+      demo: (
+        <Demo>
+          <MultiSelectField name="dd-error-bad" label="Characters" options={options} value={[]} disabled onChange={() => {}} />
+        </Demo>
+      ),
+    },
+  },
+]
+
+export const DoVsDont = () => (
+  <div className={s.doDont}>
+    {DO_DONT_PAIRS.map(({ heading, good, bad }) => (
+      <section key={heading} className={s.doDontRow}>
+        <h4 className={s.doDontHeading}>{heading}</h4>
+        <div className={`${s.doDontCard} ${s.doDontGood}`}>
+          <span className={s.doDontMarker}>
+            <Check size={14} /> Do
+          </span>
+          <div className={s.doDontDemo}>{good.demo}</div>
+          <p className={s.doDontNote}>{good.note}</p>
+        </div>
+        <div className={`${s.doDontCard} ${s.doDontBad}`}>
+          <span className={s.doDontMarker}>
+            <X size={14} /> Don&rsquo;t
+          </span>
+          <div className={s.doDontDemo}>{bad.demo}</div>
+          <p className={s.doDontNote}>{bad.note}</p>
+        </div>
+      </section>
+    ))}
+  </div>
+)
+DoVsDont.tags = ['!dev']
+DoVsDont.parameters = {
+  docs: {
+    description: {
+      story: 'Concrete good-and-bad pairings for choosing, labelling, and validating a MultiSelectField.',
+    },
+  },
+}

--- a/__stories__/MultiSelectField.stories.tsx
+++ b/__stories__/MultiSelectField.stories.tsx
@@ -52,11 +52,6 @@ export default {
     placeholder: { control: 'text', table: { category: 'Content' } },
     helperText: { control: 'text', table: { category: 'Content' } },
     error: { control: 'text', table: { category: 'State' } },
-    size: {
-      control: 'inline-radio',
-      options: ['small', 'medium'],
-      table: { category: 'Layout', defaultValue: { summary: 'medium' } },
-    },
     disabled: { control: 'boolean', table: { category: 'State' } },
     isCreatable: { control: 'boolean', table: { category: 'Behavior' } },
   },
@@ -123,18 +118,14 @@ Basic.tags = ['!dev']
 
 export const Sizes = () => {
   const [a, setA] = useState<string[]>([options[1].value, options[2].value])
-  const [b, setB] = useState<string[]>([options[1].value, options[2].value])
   return (
     <div className={s.section}>
       <Caption>
-        Two sizes: <strong>small</strong> for dense tables and toolbars, <strong>medium</strong> (default) for most forms.
+        MultiSelectField renders at a single <strong>regular</strong> size — the compact field height used across forms.
       </Caption>
       <div className={`${s.grid} ${s.gridSizes}`} style={{ gridTemplateColumns: 'repeat(2, 360px)' }}>
-        <Cell label="Small">
-          <MultiSelectField name="size-small" size="small" label="Characters" options={options} value={a} onChange={setA} />
-        </Cell>
-        <Cell label="Medium">
-          <MultiSelectField name="size-medium" label="Characters" options={options} value={b} onChange={setB} />
+        <Cell label="Regular">
+          <MultiSelectField name="size-regular" label="Characters" options={options} value={a} onChange={setA} />
         </Cell>
       </div>
     </div>

--- a/__stories__/SelectField.mdx
+++ b/__stories__/SelectField.mdx
@@ -28,7 +28,7 @@ prefer `AutocompleteField`.
 
         <h2>Sizes</h2>
 
-        <p>Two sizes — <code>small</code> for dense tables and toolbars, <code>medium</code> (default) for most forms.</p>
+        <p>SelectField renders at a single <code>regular</code> size — the compact field height used across forms.</p>
 
         <Canvas of={SelectFieldStories.Sizes} />
 

--- a/__stories__/SelectField.mdx
+++ b/__stories__/SelectField.mdx
@@ -159,6 +159,10 @@ prefer `AutocompleteField`.
         <h2>Grouping</h2>
 
         <p>Group long lists with section headings (Dark Side / Light Side). Don&rsquo;t group fewer than ~6 options — the noise outweighs the structure.</p>
+
+        <h2>Do &amp; Don&rsquo;t</h2>
+
+        <Canvas of={SelectFieldStories.DoVsDont} />
       </>
     ),
   },

--- a/__stories__/SelectField.stories.tsx
+++ b/__stories__/SelectField.stories.tsx
@@ -56,11 +56,6 @@ export default {
     placeholder: { control: 'text', table: { category: 'Content' } },
     helperText: { control: 'text', table: { category: 'Content' } },
     error: { control: 'text', table: { category: 'State' } },
-    size: {
-      control: 'inline-radio',
-      options: ['small', 'medium'],
-      table: { category: 'Layout', defaultValue: { summary: 'medium' } },
-    },
     disabled: { control: 'boolean', table: { category: 'State' } },
     isClearable: { control: 'boolean', table: { category: 'Behavior' } },
     isCreatable: { control: 'boolean', table: { category: 'Behavior' } },
@@ -122,18 +117,14 @@ Basic.tags = ['!dev']
 
 export const Sizes = () => {
   const [a, setA] = useState<string | null>(options[1].value)
-  const [b, setB] = useState<string | null>(options[1].value)
   return (
     <div className={s.section}>
       <Caption>
-        Two sizes: <strong>small</strong> for dense tables and toolbars, <strong>medium</strong> (default) for most forms.
+        SelectField renders at a single <strong>regular</strong> size — the compact field height used across forms.
       </Caption>
       <div className={`${s.grid} ${s.gridSizes}`} style={{ gridTemplateColumns: 'repeat(2, 320px)' }}>
-        <Cell label="Small">
-          <SelectField name="size-small" size="small" label="Character" options={options} value={a} onChange={setA} />
-        </Cell>
-        <Cell label="Medium">
-          <SelectField name="size-medium" label="Character" options={options} value={b} onChange={setB} />
+        <Cell label="Regular">
+          <SelectField name="size-regular" label="Character" options={options} value={a} onChange={setA} />
         </Cell>
       </div>
     </div>

--- a/__stories__/SelectField.stories.tsx
+++ b/__stories__/SelectField.stories.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useState } from 'react'
 import { Meta, StoryObj } from '@storybook/react'
 import { Form, Formik } from 'formik'
-import { Aperture } from 'react-feather'
+import { Aperture, Check, X } from 'react-feather'
 import { GroupBase } from 'react-select'
 
 import { logger } from '../src'
@@ -382,3 +382,165 @@ export const LegacyV3 = () => {
   )
 }
 LegacyV3.tags = ['!dev']
+
+type DoDontPair = {
+  heading: string
+  good: { note: string; demo: ReactNode }
+  bad: { note: string; demo: ReactNode }
+}
+
+const Demo = ({ children }: { children: ReactNode }) => <div style={{ width: '100%' }}>{children}</div>
+
+const DO_DONT_PAIRS: DoDontPair[] = [
+  {
+    heading: 'Match the control to the number of options',
+    good: {
+      note: 'Reach for a SelectField once the list is long enough (~6+) that visible radios would crowd the layout.',
+      demo: (
+        <Demo>
+          <SelectField name="dd-count-good" label="Character" options={options} value={options[1].value} onChange={() => {}} />
+        </Demo>
+      ),
+    },
+    bad: {
+      note: 'For two or three choices use a RadioGroup or SegmentedControl — don’t bury the options inside a dropdown.',
+      demo: (
+        <Demo>
+          <SelectField
+            name="dd-count-bad"
+            label="State"
+            options={[
+              { value: 'on', label: 'Enabled' },
+              { value: 'off', label: 'Disabled' },
+            ]}
+            value="on"
+            onChange={() => {}}
+          />
+        </Demo>
+      ),
+    },
+  },
+  {
+    heading: 'Keep the placeholder a short empty hint',
+    good: {
+      note: 'A few words name the empty state. It disappears as soon as a value is chosen.',
+      demo: (
+        <Demo>
+          <SelectField
+            name="dd-ph-good"
+            label="Character"
+            placeholder="Select a character"
+            options={options}
+            value={null}
+            onChange={() => {}}
+          />
+        </Demo>
+      ),
+    },
+    bad: {
+      note: 'Don’t pack instructions into the placeholder — it truncates, then vanishes once a value is picked.',
+      demo: (
+        <Demo>
+          <SelectField
+            name="dd-ph-bad"
+            label="Character"
+            placeholder="Please choose one of the available characters from the list below"
+            options={options}
+            value={null}
+            onChange={() => {}}
+          />
+        </Demo>
+      ),
+    },
+  },
+  {
+    heading: 'Drop repeated prefixes from option labels',
+    good: {
+      note: 'Strip the shared prefix so the meaningful part of each label is the first thing read.',
+      demo: (
+        <Demo>
+          <SelectField
+            name="dd-label-good"
+            label="Environment"
+            options={[
+              { value: 'prod', label: 'Production' },
+              { value: 'stg', label: 'Staging' },
+              { value: 'dev', label: 'Development' },
+            ]}
+            value="prod"
+            onChange={() => {}}
+          />
+        </Demo>
+      ),
+    },
+    bad: {
+      note: 'Repeating the field name in every row wastes width and slows scanning — especially when labels truncate.',
+      demo: (
+        <Demo>
+          <SelectField
+            name="dd-label-bad"
+            label="Environment"
+            options={[
+              { value: 'prod', label: 'Environment — Production' },
+              { value: 'stg', label: 'Environment — Staging' },
+              { value: 'dev', label: 'Environment — Development' },
+            ]}
+            value="prod"
+            onChange={() => {}}
+          />
+        </Demo>
+      ),
+    },
+  },
+  {
+    heading: 'Surface validation inline — don’t disable the field',
+    good: {
+      note: 'Use error to explain what’s wrong. The control turns invalid and the message is announced to assistive tech.',
+      demo: (
+        <Demo>
+          <SelectField name="dd-error-good" label="Character" options={options} value={null} error="Pick a character" onChange={() => {}} />
+        </Demo>
+      ),
+    },
+    bad: {
+      note: 'Don’t disable a required field to force a choice — disabled controls aren’t focusable and give the user no guidance.',
+      demo: (
+        <Demo>
+          <SelectField name="dd-error-bad" label="Character" options={options} value={null} disabled onChange={() => {}} />
+        </Demo>
+      ),
+    },
+  },
+]
+
+export const DoVsDont = () => (
+  <div className={s.doDont}>
+    {DO_DONT_PAIRS.map(({ heading, good, bad }) => (
+      <section key={heading} className={s.doDontRow}>
+        <h4 className={s.doDontHeading}>{heading}</h4>
+        <div className={`${s.doDontCard} ${s.doDontGood}`}>
+          <span className={s.doDontMarker}>
+            <Check size={14} /> Do
+          </span>
+          <div className={s.doDontDemo}>{good.demo}</div>
+          <p className={s.doDontNote}>{good.note}</p>
+        </div>
+        <div className={`${s.doDontCard} ${s.doDontBad}`}>
+          <span className={s.doDontMarker}>
+            <X size={14} /> Don&rsquo;t
+          </span>
+          <div className={s.doDontDemo}>{bad.demo}</div>
+          <p className={s.doDontNote}>{bad.note}</p>
+        </div>
+      </section>
+    ))}
+  </div>
+)
+DoVsDont.tags = ['!dev']
+DoVsDont.parameters = {
+  docs: {
+    description: {
+      story: 'Concrete good-and-bad pairings for choosing, labelling, and validating a SelectField.',
+    },
+  },
+}

--- a/__stories__/SelectField.stories.tsx
+++ b/__stories__/SelectField.stories.tsx
@@ -48,7 +48,18 @@ export default {
       canvas: { sourceState: 'hidden' },
     },
     controls: {
-      exclude: ['name', 'value', 'className', 'menuPortalTarget', 'onBlur', 'onChange', 'noOptionsMessage', 'options', 'data-test'],
+      include: [
+        'label',
+        'placeholder',
+        'helperText',
+        'error',
+        'disabled',
+        'isClearable',
+        'isCreatable',
+        'isSearchable',
+        'menuIsOpen',
+        'required',
+      ],
     },
   },
   argTypes: {
@@ -57,8 +68,10 @@ export default {
     helperText: { control: 'text', table: { category: 'Content' } },
     error: { control: 'text', table: { category: 'State' } },
     disabled: { control: 'boolean', table: { category: 'State' } },
+    required: { control: 'boolean', table: { category: 'State' } },
     isClearable: { control: 'boolean', table: { category: 'Behavior' } },
     isCreatable: { control: 'boolean', table: { category: 'Behavior' } },
+    isSearchable: { control: 'boolean', table: { category: 'Behavior' } },
     menuIsOpen: { control: 'boolean', table: { category: 'State' } },
   },
   args: {

--- a/src/components/AppHeader/SelectCluster/SelectCluster.tsx
+++ b/src/components/AppHeader/SelectCluster/SelectCluster.tsx
@@ -63,7 +63,6 @@ export const SelectCluster: FC<SelectClusterProps> = ({ clusterVersions, cluster
       name="cluster"
       label="Select Cluster"
       showAriaLabel
-      size="small"
       data-test="select-cluster"
       className={cn(styles.select, { [styles.disabled]: disabled })}
       classNames={{

--- a/src/components/AutocompleteField.module.css
+++ b/src/components/AutocompleteField.module.css
@@ -42,7 +42,7 @@
 .container :global(.hz-autocomplete-field__control) {
   cursor: text;
   color: var(--hive-color-text-v4);
-  min-height: calc(var(--hive-grid) * 9);
+  min-height: calc(var(--hive-grid) * 7.5);
   padding-left: calc(var(--hive-grid) * 3);
   padding-right: calc(var(--hive-grid) * 2);
   box-sizing: border-box;
@@ -60,10 +60,6 @@
 .container :global(.hz-autocomplete-field__dropdown-indicator) {
   color: var(--hive-color-text-secondary-v4);
   padding: 0 calc(var(--hive-grid) * 0.5);
-}
-
-.container.small :global(.hz-autocomplete-field__control) {
-  min-height: calc(var(--hive-grid) * 7.5);
 }
 
 .container.disabled {

--- a/src/components/AutocompleteField.module.css
+++ b/src/components/AutocompleteField.module.css
@@ -14,7 +14,9 @@
   position: relative;
 }
 
-.clear {
+.clear.clear {
+  --button-size: calc(var(--hive-grid) * 6);
+
   margin-left: calc(var(--hive-grid) * 1);
 }
 

--- a/src/components/AutocompleteField.module.css
+++ b/src/components/AutocompleteField.module.css
@@ -18,6 +18,7 @@
   --button-size: calc(var(--hive-grid) * 6);
 
   margin-left: calc(var(--hive-grid) * 1);
+  border-radius: var(--hive-border-radius-pill);
 }
 
 .container :global(.hz-autocomplete-field) {

--- a/src/components/AutocompleteField.module.css
+++ b/src/components/AutocompleteField.module.css
@@ -126,7 +126,7 @@
 }
 
 .menuContainer :global(.hz-autocomplete-field__menu-list) {
-  padding: calc(var(--hive-grid) * 1) 0;
+  padding: 0;
   color: var(--hive-color-text-v4);
 }
 

--- a/src/components/AutocompleteField.tsx
+++ b/src/components/AutocompleteField.tsx
@@ -9,7 +9,6 @@ import { Error, errorId } from './Error'
 import { HelpProps } from './Help'
 import { canUseDOM } from '../utils/ssr'
 import { IconButton } from './IconButton'
-import { SelectFieldSize } from './Select/SelectField'
 import { FieldHeader, FieldHeaderProps } from './FieldHeader'
 
 export type AutocompleteFieldOption = {
@@ -25,7 +24,6 @@ export type RenderOptionFunction<O = AutocompleteFieldOption> = (
 
 export type AutocompleteFieldProps = {
   'data-test'?: string
-  size?: SelectFieldSize
   className?: string
   disabled?: boolean
   error?: string
@@ -46,7 +44,7 @@ export type AutocompleteFieldProps = {
   value?: string | null
   placeholder?: string
   openMenuOnClick?: boolean
-} & Omit<FieldHeaderProps, 'id'>
+} & Omit<FieldHeaderProps, 'id' | 'size'>
 
 type GetSelectedOptionFromValueProps = {
   value?: string | null
@@ -123,7 +121,6 @@ export const AutocompleteField: React.FC<AutocompleteFieldProps> = ({
   label,
   labelClassName,
   helperText,
-  size = 'medium',
   menuPortalTarget = 'body',
   name,
   onChange,
@@ -260,7 +257,6 @@ export const AutocompleteField: React.FC<AutocompleteFieldProps> = ({
           [styles.withError]: 'error' in props,
           [styles.disabled]: disabled,
           [styles.hasError]: error,
-          [styles.small]: size === 'small',
           [styles.empty]: !value,
         },
         // Menu container is either this select itself or any other element
@@ -273,7 +269,7 @@ export const AutocompleteField: React.FC<AutocompleteFieldProps> = ({
       <FieldHeader
         label={label}
         id={id}
-        size={size}
+        size="small"
         data-test={dataTest}
         helperText={helperText}
         showAriaLabel={showAriaLabel}

--- a/src/components/AutocompleteField.tsx
+++ b/src/components/AutocompleteField.tsx
@@ -87,7 +87,7 @@ const ClearIndicator: typeof components.ClearIndicator = ({ innerProps }) => {
   // Visually impaired people will use the keyboard (backspace) to remove the value. We do not want to confuse them by allowing to focus this button.
 
   // @ts-ignore
-  return <IconButton {...innerProps} icon={X} ariaHidden variant="ghost" className={styles.clear} tabIndex={-1} />
+  return <IconButton {...innerProps} icon={X} ariaHidden variant="ghost" size="small" className={styles.clear} tabIndex={-1} />
 }
 
 export const highlightOptionText = (labelText: string, inputValue: string | undefined): ReactNode => {

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -131,7 +131,6 @@ export const Pagination: FC<PaginationProps> = ({
         options={rowsPerPageOptions}
         onChange={onChangeWrapped}
         isSearchable={false}
-        size="small"
         data-test="pagination-rows-per-page-select"
       />
     ),

--- a/src/components/Select/CheckableSelectField.tsx
+++ b/src/components/Select/CheckableSelectField.tsx
@@ -26,7 +26,6 @@ export type CheckableSelectFieldCoreStaticProps<V> = {
 export type CheckableSelectFieldExtraProps<V> = {
   options: SelectFieldOption<V>[]
   label: ReactNode
-  size?: 'small' | 'medium'
   showAriaLabel?: boolean
   helperText?: HelpProps['helperText']
   className?: string
@@ -64,7 +63,6 @@ export const CheckableSelectField = <V extends string | number = number>(props: 
     options,
     onChange,
     value,
-    size = 'small',
     placeholder = 'Search',
     placeholderMode = 'normal',
     label,
@@ -138,7 +136,7 @@ export const CheckableSelectField = <V extends string | number = number>(props: 
     <>
       <div className={styles.openerWrap} onClick={handleOpenerClick}>
         <TextField
-          size={size}
+          size="small"
           name={name}
           id={rootId || id}
           onKeyDown={handleKeyDown}
@@ -176,7 +174,7 @@ export const CheckableSelectField = <V extends string | number = number>(props: 
           <div className={styles.search}>
             {searchInputProps.startAdornment}
             <TextField
-              size={size}
+              size="small"
               iconSize="medium"
               className={styles.searchField}
               name="checkable-select-search"

--- a/src/components/Select/Common.module.css
+++ b/src/components/Select/Common.module.css
@@ -14,8 +14,11 @@
   color: var(--hive-color-text-secondary-v4);
 }
 
-.clear {
+.clear.clear {
+  --button-size: calc(var(--hive-grid) * 6);
+
   margin-left: calc(var(--hive-grid) * 1);
+  border-radius: var(--hive-border-radius-pill);
 }
 
 [class].valueContainer {

--- a/src/components/Select/Common.tsx
+++ b/src/components/Select/Common.tsx
@@ -24,7 +24,7 @@ const ClearIndicator: typeof rsComponents.ClearIndicator = ({ innerProps }) => (
   // Visually impaired people will use the keyboard (backspace) to remove the value. We do not want to confuse them by allowing to focus this button.
 
   // @ts-ignore
-  <IconButton {...innerProps} icon={X} ariaHidden variant="ghost" className={styles.clear} tabIndex={-1} />
+  <IconButton {...innerProps} icon={X} ariaHidden variant="ghost" size="small" className={styles.clear} tabIndex={-1} />
 )
 
 const Input: typeof rsComponents.Input = (innerProps) => {

--- a/src/components/Select/Common.tsx
+++ b/src/components/Select/Common.tsx
@@ -14,7 +14,7 @@ const DropdownIndicator: typeof rsComponents.DropdownIndicator = ({ selectProps 
   <Icon
     icon={ChevronDown}
     ariaHidden
-    size="medium"
+    size="small"
     className={cn(styles.chevron, { [styles.open]: selectProps.menuIsOpen, [styles.disabled]: selectProps.isDisabled })}
   />
 )

--- a/src/components/Select/MultiSelectField.module.css
+++ b/src/components/Select/MultiSelectField.module.css
@@ -5,7 +5,7 @@
 .multiContainer :global(.hz-select-field__indicators) {
   align-items: center;
   align-self: flex-start;
-  height: calc(var(--hive-grid) * 7.5);
+  height: calc(var(--hive-grid) * 7.5 - var(--hive-border-width) * 2);
 }
 
 .multiContainer .multiValue {

--- a/src/components/Select/MultiSelectField.module.css
+++ b/src/components/Select/MultiSelectField.module.css
@@ -5,10 +5,6 @@
 .multiContainer :global(.hz-select-field__indicators) {
   align-items: center;
   align-self: flex-start;
-  height: calc(var(--hive-grid) * 9);
-}
-
-.multiContainer.small :global(.hz-select-field__indicators) {
   height: calc(var(--hive-grid) * 7.5);
 }
 

--- a/src/components/Select/MultiSelectField.tsx
+++ b/src/components/Select/MultiSelectField.tsx
@@ -104,7 +104,7 @@ export type MultiSelectFieldExtraProps<V> = {
     | 'isClearable'
     | 'onInputChange'
   > &
-  Omit<FieldHeaderProps, 'id'>
+  Omit<FieldHeaderProps, 'id' | 'size'>
 
 export type MultiSelectProps<V> = MultiSelectFieldCoreStaticProps<V> & MultiSelectFieldExtraProps<V>
 
@@ -222,8 +222,6 @@ export const MultiSelectField = <V extends string | number = number>(props: Mult
           [styles.hasError]: error,
           [styles.empty]: !value,
           [styles.withError]: 'error' in props,
-          [styles.small]: rest.size === 'small',
-          [multiStyles.small]: rest.size === 'small',
         },
         multiStyles.multiContainer,
         className,
@@ -232,7 +230,7 @@ export const MultiSelectField = <V extends string | number = number>(props: Mult
       <FieldHeader
         id={id}
         label={label}
-        size={rest.size}
+        size="small"
         helperText={helperText}
         showAriaLabel={showAriaLabel}
         labelClassName={labelClassName}

--- a/src/components/Select/SelectField.module.css
+++ b/src/components/Select/SelectField.module.css
@@ -144,7 +144,7 @@
 }
 
 .menuContainer.menuContainer.menuContainer :global(.hz-select-field__menu-list) {
-  padding: calc(var(--hive-grid) * 1) 0;
+  padding: 0;
   color: var(--hive-color-text-v4);
 }
 

--- a/src/components/Select/SelectField.module.css
+++ b/src/components/Select/SelectField.module.css
@@ -50,6 +50,11 @@
   display: none;
 }
 
+.container :global(.hz-select-field__indicators) svg {
+  width: calc(var(--hive-grid) * 4);
+  height: calc(var(--hive-grid) * 4);
+}
+
 .container :global(.hz-select-field__input-container),
 .container :global(.hz-select-field__input) {
   color: var(--hive-color-text-v4);

--- a/src/components/Select/SelectField.module.css
+++ b/src/components/Select/SelectField.module.css
@@ -50,11 +50,6 @@
   display: none;
 }
 
-.container :global(.hz-select-field__indicators) svg {
-  width: calc(var(--hive-grid) * 4);
-  height: calc(var(--hive-grid) * 4);
-}
-
 .container :global(.hz-select-field__input-container),
 .container :global(.hz-select-field__input) {
   color: var(--hive-color-text-v4);

--- a/src/components/Select/SelectField.module.css
+++ b/src/components/Select/SelectField.module.css
@@ -23,7 +23,7 @@
 .container :global(.hz-select-field__control) {
   cursor: pointer;
   color: var(--hive-color-text-v4);
-  min-height: calc(var(--hive-grid) * 9);
+  min-height: calc(var(--hive-grid) * 7.5);
   padding-left: calc(var(--hive-grid) * 3);
   padding-right: calc(var(--hive-grid) * 2);
   box-sizing: border-box;
@@ -58,10 +58,6 @@
 .container :global(.hz-select-field__input-container),
 .container :global(.hz-select-field__input) {
   color: var(--hive-color-text-v4);
-}
-
-.container.small :global(.hz-select-field__control) {
-  min-height: calc(var(--hive-grid) * 7.5);
 }
 
 .container.disabled {
@@ -128,10 +124,6 @@
   padding-left: calc(var(--hive-grid) * 7);
 }
 
-.container.hasIcon.small :global(.hz-select-field__control) {
-  padding-left: calc(var(--hive-grid) * 7);
-}
-
 .menuContainer.menuContainer.menuContainer :global(.hz-select-field__menu-portal) {
   z-index: 2000;
 }
@@ -158,8 +150,8 @@
 
 .menuContainer.menuContainer.menuContainer :global(.hz-select-field__option),
 .menuContainer.menuContainer.menuContainer :global(.hz-select-field__menu-notice) {
-  min-height: calc(var(--hive-grid) * 10);
-  line-height: calc(var(--hive-grid) * 10);
+  min-height: calc(var(--hive-grid) * 8);
+  line-height: calc(var(--hive-grid) * 8);
   padding: 0 calc(var(--hive-grid) * 3);
   background-color: transparent;
   color: var(--hive-color-text-v4);
@@ -167,12 +159,6 @@
   text-align: left;
   cursor: pointer;
   text-decoration: none;
-}
-
-.menuContainer.menuContainer.menuContainer :global(.hz-select-field__option.small),
-.menuContainer.menuContainer.menuContainer :global(.hz-select-field__menu-notice.small) {
-  min-height: calc(var(--hive-grid) * 8);
-  line-height: calc(var(--hive-grid) * 8);
 }
 
 .menuContainer.menuContainer.menuContainer :global(.hz-select-field__option--is-focused) {

--- a/src/components/Select/SelectField.tsx
+++ b/src/components/Select/SelectField.tsx
@@ -39,11 +39,10 @@ export type SelectFieldIconLeftProps =
       iconLeftContainerClassName?: never
     }
 
-export type SelectFieldSize = 'small' | 'medium'
+export type SelectFieldSize = 'regular'
 
 export type SelectFieldExtraProps<V> = {
   options: ReadonlyArray<GroupBase<SelectFieldOption<V>>> | Options<SelectFieldOption<V>>
-  size?: SelectFieldSize
   // Since the user input is string, let's allow creatable only for string
   isCreatable?: V extends string ? boolean : false
   className?: string
@@ -71,7 +70,7 @@ export type SelectFieldExtraProps<V> = {
     | 'menuShouldBlockScroll'
   > &
   SelectFieldIconLeftProps &
-  Omit<FieldHeaderProps, 'id'>
+  Omit<FieldHeaderProps, 'id' | 'size'>
 
 export type SelectFieldProps<V> = SelectFieldCoreStaticProps<V> & SelectFieldExtraProps<V>
 
@@ -89,7 +88,6 @@ export const SelectField = <V extends string | number = string>(props: SelectFie
     label,
     labelClassName,
     showAriaLabel = false,
-    size = 'medium',
     menuIsOpen,
     menuPortalTarget = 'body',
     menuPlacement = 'auto',
@@ -190,7 +188,6 @@ export const SelectField = <V extends string | number = string>(props: SelectFie
     // @ts-ignore
     renderMenuFooter,
     menuShouldScrollIntoView,
-    classNames: { option: () => size },
     ...rest,
   }
 
@@ -208,7 +205,6 @@ export const SelectField = <V extends string | number = string>(props: SelectFie
           [styles.hasError]: error,
           [styles.empty]: !value,
           [styles.hasIcon]: !!iconLeft,
-          [styles.small]: size === 'small',
           [styles.withError]: 'error' in props,
         },
         className,
@@ -217,7 +213,7 @@ export const SelectField = <V extends string | number = string>(props: SelectFie
       <FieldHeader
         label={label}
         id={id}
-        size={size}
+        size="small"
         data-test={dataTest}
         helperText={helperText}
         showAriaLabel={showAriaLabel}


### PR DESCRIPTION
## Summary
Master's HIVE v4 SelectField (from #633 / hzc-7906) renders the dropdown chevron via `Icon size="medium"` = **24px**, but the Figma spec calls for **16px**. This adds an explicit rule sizing the indicator svg down.

## Change
```css
.container :global(.hz-select-field__indicators) svg {
  width: calc(var(--hive-grid) * 4);  /* 0.25rem * 4 = 16px */
  height: calc(var(--hive-grid) * 4);
}
```

## Why it works
The svg's `width="1em"` is a presentational *attribute* (lowest cascade priority), so this CSS rule wins over `Icon`'s `.medium` rule on specificity — no `!important` needed.

## Verification
Confirmed live in Storybook (`components-selectfield--basic`): the chevron renders at exactly **16×16px** (bounding box + computed style).

## Scope
Self-contained follow-up to the merged hzc-7906 redesign. Touches only `SelectField.module.css`.