### PR TITLE
hzc-0000: fix interactivelistformik size

### DIFF
--- a/src/components/InteractiveList.module.css
+++ b/src/components/InteractiveList.module.css
@@ -15,8 +15,8 @@
   border: var(--hive-border-width) solid transparent;
   background-color: var(--hive-color-secondary-v4);
   color: var(--hive-color-text-v4);
-  width: calc(var(--hive-grid) * 9);
-  height: calc(var(--hive-grid) * 9);
+  width: calc(var(--hive-grid) * 7.5);
+  height: calc(var(--hive-grid) * 7.5);
 }
 
 .addIcon:hover,
@@ -37,7 +37,7 @@
   justify-content: space-between;
   align-items: center;
   margin-top: calc(var(--hive-grid) * 3);
-  min-height: calc(var(--hive-grid) * 9);
+  min-height: calc(var(--hive-grid) * 7.5);
   padding: 0 calc(var(--hive-grid) * 2);
   border: var(--hive-border-width) solid var(--hive-color-border-v4);
   border-radius: var(--hive-border-radius);

--- a/src/components/InteractiveList.tsx
+++ b/src/components/InteractiveList.tsx
@@ -109,6 +109,7 @@ export const InteractiveList = <V,>({
       <div data-test={dataTest} className={cn(styles.inputRow, className)}>
         <TextField
           id={id}
+          size="small"
           type={type}
           helperText={helperText}
           placeholder={placeholder}


### PR DESCRIPTION
Shrinks InteractiveListFormik to HIVE's compact field size. The input now uses TextField size="small" (30px) and the add button + item chips were reduced from grid*9 (36px) to grid*7.5 (30px) to match. No API change.